### PR TITLE
fix(booking): enable Google Meet creation via DWD impersonation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,34 @@
+# Copy this file to `.env` in the backend/ directory and fill in real values.
+# `main.go` loads this automatically via godotenv.
+
+# --- Service ---
+PORT=8080
+
+# --- SMTP (email sending) ---
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SEND_FROM=nikolay.tonev@ivmanto.com
+SEND_FROM_ALIAS=IVMANTO Accounts
+SMTP_PASS=REPLACE_WITH_APP_PASSWORD
+
+# --- Google Calendar / DWD ---
+CALENDAR_ID=c_2950137553d97197f3e7963a9543784e119032ca9cc1b970ea668c6e9d2c9764@group.calendar.google.com
+GCAL_AVAILABLE_SLOT_SUMMARY=AfB
+GCAL_SA_EMAIL=ivmanto-backend-sa@ivmanto-com-prod.iam.gserviceaccount.com
+GCAL_IMPERSONATE_USER=nikolay.tonev@ivmanto.com
+
+# --- GCP project ---
+GCP_PROJECT_ID=ivmanto-com-prod
+GCP_LOCATION=europe-west3
+
+# --- Blog (GCS) ---
+GCS_BLOG_BUCKET=ivmanto_com_blog_articles
+
+# --- Google Analytics ---
+GA_MEASUREMENT_ID=G-W1TJ3KMZ6V
+GA_API_SECRET=REPLACE_WITH_GA_API_SECRET
+
+# --- Optional ---
+# PUBSUB_PUSH_TOKEN=
+# FRONTEND_REBUILD_WEBHOOK_URL=
+# GENERATE_IDEAS_PROMPT_TEMPLATE=

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 gcp-credentials.json
+.env
+.env.local

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -37,6 +37,8 @@ type EmailConfig struct {
 type GCalConfig struct {
 	CalendarID           string
 	AvailableSlotSummary string
+	ServiceAccountEmail  string // Runtime SA email, used as the impersonation source for DWD.
+	ImpersonateUser      string // Workspace user to impersonate via Domain-Wide Delegation.
 }
 
 // GCPConfig holds project-level Google Cloud configuration.
@@ -98,6 +100,14 @@ func Load() (*Config, error) {
 	if availableSlotSummary == "" {
 		missingVars = append(missingVars, "GCAL_AVAILABLE_SLOT_SUMMARY")
 	}
+	gcalSAEmail := os.Getenv("GCAL_SA_EMAIL")
+	if gcalSAEmail == "" {
+		missingVars = append(missingVars, "GCAL_SA_EMAIL")
+	}
+	gcalImpersonateUser := os.Getenv("GCAL_IMPERSONATE_USER")
+	if gcalImpersonateUser == "" {
+		missingVars = append(missingVars, "GCAL_IMPERSONATE_USER")
+	}
 
 	projectID, err := metadata.ProjectID()
 	if err != nil {
@@ -140,7 +150,12 @@ func Load() (*Config, error) {
 	return &Config{
 		Service: ServiceConfig{Port: port},
 		Email:   EmailConfig{SmtpHost: smtpHost, SmtpPort: smtpPort, SendFrom: sendFrom, SendFromAlias: sendFromAlias, SmtpPass: smtpPass},
-		GCal:    GCalConfig{CalendarID: calendarID, AvailableSlotSummary: availableSlotSummary},
+		GCal: GCalConfig{
+			CalendarID:           calendarID,
+			AvailableSlotSummary: availableSlotSummary,
+			ServiceAccountEmail:  gcalSAEmail,
+			ImpersonateUser:      gcalImpersonateUser,
+		},
 		GCP:     GCPConfig{ProjectID: projectID, Location: location},
 		Ideas:   IdeasConfig{GenerateIdeasPromptTemplate: generateIdeasPromptTemplate},
 		Analytics: AnalyticsConfig{

--- a/backend/internal/gcal/calendar.go
+++ b/backend/internal/gcal/calendar.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 	"ivmanto.com/backend/internal/config"
 )
@@ -45,16 +46,25 @@ type BookingDetails struct {
 	Notes   string
 }
 
-// NewService creates a new calendar service client using Application Default Credentials.
-// On GCP, this uses the attached service account. For local dev, it uses `gcloud auth application-default login`.
+// NewService creates a new calendar service client using Domain-Wide Delegation.
+// The runtime principal (ADC) impersonates the configured service account, which in turn
+// impersonates a Workspace user via DWD. This is required so that Google Meet conferences
+// can be created on the calendar events.
 func NewService(ctx context.Context, cfg *config.Config) (Service, error) {
-	slog.Info("Authenticating for Google Calendar using Application Default Credentials")
+	slog.Info("Authenticating for Google Calendar via DWD user impersonation",
+		"sa", cfg.GCal.ServiceAccountEmail,
+		"subject", cfg.GCal.ImpersonateUser)
 
-	// Application Default Credentials (ADC) will be used automatically.
-	// On Cloud Run, this is the attached service account.
-	// Locally, this is the identity from `gcloud auth application-default login`.
-	// We just need to specify the required scope.
-	srv, err := calendar.NewService(ctx, option.WithScopes(calendar.CalendarScope))
+	ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+		TargetPrincipal: cfg.GCal.ServiceAccountEmail,
+		Scopes:          []string{calendar.CalendarScope},
+		Subject:         cfg.GCal.ImpersonateUser,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create impersonated token source: %w", err)
+	}
+
+	srv, err := calendar.NewService(ctx, option.WithTokenSource(ts))
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve Calendar client: %w", err)
 	}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -82,6 +82,8 @@ steps:
       # Set environment variables one by one for clarity and to avoid parsing issues with complex strings.
       - '--set-env-vars=CALENDAR_ID=${_CALENDAR_ID}'
       - '--set-env-vars=GCAL_AVAILABLE_SLOT_SUMMARY=${_GCAL_AVAILABLE_SLOT_SUMMARY}'
+      - '--set-env-vars=GCAL_SA_EMAIL=${_GCAL_SA_EMAIL}'
+      - '--set-env-vars=GCAL_IMPERSONATE_USER=${_GCAL_IMPERSONATE_USER}'
       - '--set-env-vars=SMTP_HOST=${_SMTP_HOST}'
       - '--set-env-vars=SMTP_PORT=${_SMTP_PORT}'
       - '--set-env-vars=SEND_FROM=${_SEND_FROM}'
@@ -103,6 +105,8 @@ substitutions:
   # These must be configured in the Cloud Build Trigger UI.
   _CALENDAR_ID: 'c_2950137553d97197f3e7963a9543784e119032ca9cc1b970ea668c6e9d2c9764@group.calendar.google.com' # Example, but likely correct
   _GCAL_AVAILABLE_SLOT_SUMMARY: 'AfB' # Example, but likely correct
+  _GCAL_SA_EMAIL: 'ivmanto-backend-sa@ivmanto-com-prod.iam.gserviceaccount.com'
+  _GCAL_IMPERSONATE_USER: 'nikolay.tonev@ivmanto.com'
   _SMTP_HOST: 'smtp.gmail.com' # e.g., 'smtp.gmail.com' - Set in Trigger UI
   _SMTP_PORT: '587' # e.g., '587' - Set in Trigger UI
   _SEND_FROM: 'nikolay.tonev@ivmanto.com' # e.g., 'contact@ivmanto.com' - Set in Trigger UI


### PR DESCRIPTION
## Summary
- Fixes the `"An internal error occurred while creating the booking."` error on `/booking` confirmation.
- Root cause: commit `f0034d2` re-introduced Google Meet conference creation (`ConferenceDataVersion(1)`), which fails under plain ADC because the service account has no user identity to own the Meet.
- Fix: switch the calendar client to **Domain-Wide Delegation** via `impersonate.CredentialsTokenSource` with `Subject` set to a Workspace user.

## Changes
- `backend/internal/gcal/calendar.go` — use `impersonate.CredentialsTokenSource` with `Subject`.
- `backend/internal/config/config.go` — two new required env vars: `GCAL_SA_EMAIL`, `GCAL_IMPERSONATE_USER`.
- `cloudbuild.yaml` — pass the two new env vars via substitutions.
- `backend/.env.example` — template for local dev.
- `backend/.gitignore` — ignore `.env` / `.env.local`.

## Prerequisites (already done manually)
- [x] DWD authorized in Workspace Admin with scope `https://www.googleapis.com/auth/calendar`
- [x] Calendar shared with the impersonated user
- [x] `roles/iam.serviceAccountTokenCreator` granted to the SA on itself

## Test plan
- [ ] Cloud Build deploys the new revision successfully
- [ ] `/booking` availability loads
- [ ] Submitting a booking succeeds (no "internal error")
- [ ] Confirmation email contains a Google Meet link

🤖 Generated with [Claude Code](https://claude.com/claude-code)