### PR TITLE
Release dev-v0.1.3 — featured services & AI search discovery

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "ivmanto-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    },
+    {
+      "name": "ivmanto-static",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["-y", "serve", ".output/public", "-l", "4000"],
+      "port": 4000
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ coverage
 .output/
 
 # Claude Code local session data
-.claude/
+.claude/*
+!.claude/launch.json
 
 /cypress/videos/
 /cypress/screenshots/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository layout
+
+This is a monorepo with two independent services:
+
+- **`/` (root)** — Nuxt 3 SSG frontend (Node/TypeScript)
+- **`/backend`** — Go HTTP backend (module `ivmanto.com/backend`)
+
+Each has its own `Dockerfile` and is deployed as a separate Cloud Run service via `cloudbuild.yaml`.
+
+## Local development
+
+**Backend** — requires a `backend/.env` file (copy from `backend/.env.example`):
+```bash
+cd backend && go run ./cmd/server   # listens on :8080
+```
+On startup the backend initialises all clients (GCS, Vertex AI, Google Calendar, SMTP). If any required env var is missing, it exits immediately — check the log for `"missing required environment variables"`.
+
+For GCP APIs locally: `gcloud auth application-default login` then `gcloud auth application-default set-quota-project ivmanto-com-prod`.
+
+**Frontend** — proxies `/api/*` to `localhost:8080` in dev mode:
+```bash
+npm install && npm run dev   # listens on :3000
+```
+
+## Common commands
+
+```bash
+# Frontend
+npm run lint       # ESLint + auto-fix
+npm run format     # Prettier
+npm run generate   # SSG build (what Cloud Build runs)
+
+# Backend
+cd backend
+go build ./...
+go test ./...
+go test ./internal/gcal/...   # run a single package's tests
+```
+
+## Architecture
+
+### Request flow
+
+```
+Browser → Nuxt frontend (Cloud Run)
+              └─ /api/* → Go backend (Cloud Run)
+                              ├─ /api/booking/*    → Google Calendar API (via DWD impersonation)
+                              ├─ /api/blog/*       → GCS bucket (markdown) → in-memory cache
+                              ├─ /api/contact      → SMTP
+                              ├─ /api/ideas        → Vertex AI (Gemini)
+                              └─ /api/articles     → in-memory likes counter
+```
+
+### Backend packages (`backend/internal/`)
+
+| Package | Role |
+|---|---|
+| `config` | Loads all env vars at startup; exits if any required var is missing |
+| `gcal` | Google Calendar wrapper — fetches availability, books/cancels slots, creates Meet conferences |
+| `booking` | HTTP handler for `/api/booking/*`; orchestrates gcal + email + analytics |
+| `email` | SMTP service; HTML templates live in `email/*.html` |
+| `blog` | GCS-backed blog pipeline with Pub/Sub-triggered in-memory cache refresh |
+| `ideas` | Vertex AI GenAI handler; prompt template configurable via env/Secret Manager |
+| `analytics` | GA4 Measurement Protocol client for server-side conversion tracking |
+| `middleware` | CORS (allow-all) and structured JSON request logging |
+| `contact` | Contact form → SMTP email |
+
+### Google Calendar / booking
+
+Available time slots are Google Calendar events whose `Summary` matches `GCAL_AVAILABLE_SLOT_SUMMARY` (env var, currently `AfB`). Booking updates the event in-place (atomic via ETag). Google Meet conferences are created via `ConferenceDataVersion(1)` on the update call.
+
+**Auth:** The backend uses Domain-Wide Delegation (DWD) — `impersonate.CredentialsTokenSource` with `Subject` set to `GCAL_IMPERSONATE_USER`. This is required because plain service-account ADC cannot create Google Meet conferences. The DWD scope (`https://www.googleapis.com/auth/calendar`) must be authorised in the Workspace Admin Console for the service account's OAuth client ID.
+
+### Frontend → backend in production
+
+`NUXT_API_BASE_URL` build arg (set in `cloudbuild.yaml`) is `https://ivmanto.com`. At build time, SSG pages that need backend data (e.g. blog article list) fetch from this URL. Runtime `/api/*` calls from the browser hit the same domain and are load-balanced to the backend Cloud Run service.
+
+## Deployment
+
+Push to `main` triggers Cloud Build (`cloudbuild.yaml`), which:
+1. Builds and pushes both Docker images to Artifact Registry (`europe-west3`)
+2. Deploys frontend and backend to Cloud Run (`europe-west3`, project `ivmanto-com-prod`)
+3. Backend secrets (`SMTP_PASS`, `GA_API_SECRET`, etc.) are injected from Secret Manager; non-secret config comes from substitution variables in the trigger
+
+Working branches follow the pattern `dev-vX.Y.Z`. Merge to `main` via PR — branch protection requires checks to pass.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,79 @@
 # ivmanto.com
 
-This template should help get you started developing with Vue 3 in Vite.
+The website for IVMANTO — a Data & AI consultancy specializing in Google Cloud
+Platform. This is a monorepo containing two independently deployed services.
 
-## Recommended IDE Setup
+## Repository layout
 
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
+| Path        | Service           | Stack                        |
+| ----------- | ----------------- | ---------------------------- |
+| `/` (root)  | Frontend website  | Nuxt 3 (SSG), TypeScript     |
+| `/backend`  | HTTP API backend  | Go (module `ivmanto.com/backend`) |
 
-## Type Support for `.vue` Imports in TS
+Each service has its own `Dockerfile` and is deployed as a separate Cloud Run
+service via `cloudbuild.yaml`.
 
-TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to make the TypeScript language service aware of `.vue` types.
+## Architecture
 
-## Customize configuration
+```
+Browser → Nuxt frontend (Cloud Run)
+              └─ /api/* → Go backend (Cloud Run)
+                              ├─ /api/booking/*  → Google Calendar (DWD impersonation)
+                              ├─ /api/blog/*     → GCS bucket (markdown)
+                              ├─ /api/contact    → SMTP
+                              ├─ /api/ideas      → Vertex AI (Gemini)
+                              └─ /api/articles   → in-memory likes counter
+```
 
-See [Vite Configuration Reference](https://vite.dev/config/).
+## Local development
 
-## Project Setup
+### Frontend
 
 ```sh
 npm install
+npm run dev        # http://localhost:3000  (proxies /api/* to :8080)
 ```
 
-### Compile and Hot-Reload for Development
+### Backend
+
+Requires a `backend/.env` file (copy from `backend/.env.example`):
 
 ```sh
-npm run dev
+cd backend && go run ./cmd/server   # http://localhost:8080
 ```
 
-### Type-Check, Compile and Minify for Production
+For GCP APIs locally:
 
 ```sh
-npm run build
+gcloud auth application-default login
+gcloud auth application-default set-quota-project ivmanto-com-prod
 ```
 
-### Lint with [ESLint](https://eslint.org/)
+## Common commands
 
 ```sh
-npm run lint
+# Frontend
+npm run dev        # dev server
+npm run generate   # static (SSG) build — what Cloud Build runs
+npm run format     # Prettier
+
+# Backend
+cd backend
+go build ./...
+go test ./...
 ```
+
+## Deployment
+
+Pushing to `main` triggers Cloud Build (`cloudbuild.yaml`), which builds and
+pushes both Docker images to Artifact Registry and deploys the frontend and
+backend to Cloud Run (`europe-west3`, project `ivmanto-com-prod`). Backend
+secrets are injected from Secret Manager.
+
+Working branches follow the `dev-vX.Y.Z` pattern and merge to `main` via pull
+request; branch protection requires checks to pass.
+
+## Further documentation
+
+- `CLAUDE.md` — detailed architecture and conventions
+- `docs/features/dev-vX.Y.Z/` — per-release working notes and release notes

--- a/backend/scripts/dwd_meet_test.py
+++ b/backend/scripts/dwd_meet_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+DWD + Google Meet smoke test.
+
+Mirrors the Go production flow at backend/internal/gcal/calendar.go:
+    impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+        TargetPrincipal: cfg.GCal.ServiceAccountEmail,
+        Scopes:          []string{calendar.CalendarScope},
+        Subject:         cfg.GCal.ImpersonateUser,
+    })
+    ...
+    Events.Update(...).ConferenceDataVersion(1).Do()
+
+Auth chain (no service-account key file is used):
+    Local ADC  ->  iam.serviceAccounts.signJwt on the SA
+                ->  SA acts as the Workspace user via DWD
+                ->  Calendar API call signed as that user
+
+Prerequisites:
+  1. ADC: `gcloud auth application-default login` (or workload identity).
+  2. The ADC principal must have BOTH of these on the target SA:
+        roles/iam.serviceAccountTokenCreator
+        roles/iam.serviceAccountOpenIdTokenCreator   (sometimes required for signJwt)
+     Verify with:
+        gcloud iam service-accounts get-iam-policy $GCAL_SA_EMAIL
+  3. The SA's OAuth client ID must be authorised in the Workspace Admin Console
+     (Security -> Access and data control -> API controls -> Domain-wide delegation)
+     for the scope: https://www.googleapis.com/auth/calendar
+
+Install:
+    pip install google-auth>=2.18.0 google-api-python-client
+
+Run:
+    python dwd_meet_test.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import google.auth
+from google.auth import impersonated_credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+
+# Defaults match the cloudbuild.yaml substitutions used by the Go backend.
+SA_EMAIL = os.environ.get(
+    "GCAL_SA_EMAIL",
+    "ivmanto-backend-sa@ivmanto-com-prod.iam.gserviceaccount.com",
+)
+SUBJECT_USER = os.environ.get(
+    "GCAL_IMPERSONATE_USER",
+    "nikolay.tonev@ivmanto.com",
+)
+CALENDAR_ID = os.environ.get(
+    "CALENDAR_ID",
+    "c_2950137553d97197f3e7963a9543784e119032ca9cc1b970ea668c6e9d2c9764@group.calendar.google.com",
+)
+SCOPES = ["https://www.googleapis.com/auth/calendar"]
+
+
+def build_calendar_service():
+    """ADC -> impersonate SA -> act as Workspace user via DWD subject."""
+    source_creds, project = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    print(f"[auth] ADC project: {project}", file=sys.stderr)
+    print(f"[auth] target SA  : {SA_EMAIL}", file=sys.stderr)
+    print(f"[auth] DWD subject: {SUBJECT_USER}", file=sys.stderr)
+
+    target_creds = impersonated_credentials.Credentials(
+        source_credentials=source_creds,
+        target_principal=SA_EMAIL,
+        target_scopes=SCOPES,
+        subject=SUBJECT_USER,  # <-- this is the DWD lever (== Go's `Subject`)
+    )
+
+    return build("calendar", "v3", credentials=target_creds, cache_discovery=False)
+
+
+def create_event_with_meet():
+    service = build_calendar_service()
+
+    start = datetime.now(timezone.utc) + timedelta(hours=2)
+    end = start + timedelta(minutes=30)
+
+    body = {
+        "summary": "DWD + Meet sanity check",
+        "description": (
+            "Created by dwd_meet_test.py. Safe to delete.\n"
+            "If this event has a Google Meet link, DWD is working."
+        ),
+        "start": {"dateTime": start.isoformat()},
+        "end": {"dateTime": end.isoformat()},
+        # Same shape used in the Go backend (calendar.go:179-187).
+        "conferenceData": {
+            "createRequest": {
+                "requestId": str(uuid.uuid4()),
+                "conferenceSolutionKey": {"type": "hangoutsMeet"},
+            },
+        },
+    }
+
+    event = (
+        service.events()
+        .insert(
+            calendarId=CALENDAR_ID,
+            body=body,
+            conferenceDataVersion=1,  # required, same as Go
+            sendUpdates="none",
+        )
+        .execute()
+    )
+    return event
+
+
+def main() -> int:
+    try:
+        event = create_event_with_meet()
+    except HttpError as e:
+        print(f"\n[FAIL] HTTP {e.status_code} {e.reason}", file=sys.stderr)
+        print(e.content.decode("utf-8", errors="replace"), file=sys.stderr)
+        return 1
+    except Exception as e:  # noqa: BLE001
+        print(f"\n[FAIL] {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+
+    print("\n[OK] DWD + Meet creation succeeded:")
+    print(f"  event id   : {event.get('id')}")
+    print(f"  html link  : {event.get('htmlLink')}")
+    print(f"  meet link  : {event.get('hangoutLink')}")
+
+    cd = event.get("conferenceData") or {}
+    entry_points = cd.get("entryPoints") or []
+    if entry_points:
+        print("  entryPoints:")
+        for ep in entry_points:
+            print(f"    - {ep.get('entryPointType')}: {ep.get('uri')}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/components/PrivacyPolicy.vue
+++ b/components/PrivacyPolicy.vue
@@ -58,7 +58,7 @@
         parts of our Service.
       </li>
       <li>
-        <strong>Website</strong> refers to ivmanto.com, accessible from https://www.ivmanto.com
+        <strong>Website</strong> refers to ivmanto.com, accessible from https://ivmanto.com
       </li>
       <li><strong>Service</strong> refers to the Website.</li>
       <li><strong>Country</strong> refers to: Germany</li>
@@ -569,7 +569,7 @@
       <li>By email: nikolay.tonev@ivmanto.com</li>
       <li>
         By visiting this page on our website:
-        <a href="https://www.ivmanto.com/#contact">Contact Us</a>
+        <a href="https://ivmanto.com/#contact">Contact Us</a>
       </li>
     </ul>
   </div>

--- a/components/services-content/AgenticAiSolutions.vue
+++ b/components/services-content/AgenticAiSolutions.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+const { cleanTitle } = usePageMetadata()
+</script>
+
+<template>
+  <article class="prose prose-sm lg:prose-base max-w-none p-6">
+    <h1>{{ cleanTitle }}</h1>
+    <p class="italic lg:text-l">
+      Beyond chatbots — autonomous agents that reason, act, and collaborate.
+    </p>
+    <hr class="border-gray-200 my-2" />
+    <p>
+      Go beyond basic chatbots. We specialize in designing and implementing next-generation
+      <strong>Agentic AI solutions</strong> — autonomous agents capable of executing complex tasks,
+      reasoning, and collaborating. Working side-by-side with your internal engineering or product
+      teams, we provide the <strong>architectural guidance</strong>, best practices, and
+      implementation support needed to deploy <strong>intelligent workflows</strong> that deliver
+      tangible business outcomes.
+    </p>
+    <h4>Key Deliverables</h4>
+    <ul>
+      <li><strong>Multi-agent system architecture</strong></li>
+      <li><strong>Technical implementation guidance</strong></li>
+      <li><strong>Team workshops</strong></li>
+    </ul>
+  </article>
+</template>

--- a/components/services-content/AiAutomationDiscovery.vue
+++ b/components/services-content/AiAutomationDiscovery.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+const { cleanTitle } = usePageMetadata()
+</script>
+
+<template>
+  <article class="prose prose-sm lg:prose-base max-w-none p-6">
+    <h1>{{ cleanTitle }}</h1>
+    <p class="italic lg:text-l">
+      Cutting through the hype to find AI and automation that actually pays off.
+    </p>
+    <hr class="border-gray-200 my-2" />
+    <p>
+      Many small and medium-sized businesses want to leverage AI but don't know where to start. We
+      help SMBs bypass the hype and identify
+      <strong>high-impact, practical use-cases</strong> for automation. By auditing your current
+      workflows, we pinpoint bottlenecks and design a clear <strong>automation roadmap</strong> that
+      directly reduces operational costs and scales your capabilities.
+    </p>
+    <h4>Key Deliverables</h4>
+    <ul>
+      <li><strong>Workflow assessments</strong></li>
+      <li><strong>ROI prioritization</strong></li>
+      <li><strong>Actionable automation roadmaps</strong></li>
+    </ul>
+  </article>
+</template>

--- a/components/services-content/DataPipelineEngineering.vue
+++ b/components/services-content/DataPipelineEngineering.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+const { cleanTitle } = usePageMetadata()
+</script>
+
+<template>
+  <article class="prose prose-sm lg:prose-base max-w-none p-6">
+    <h1>{{ cleanTitle }}</h1>
+    <p class="italic lg:text-l">
+      Reliable, scalable pipelines that turn raw data into real business value.
+    </p>
+    <hr class="border-gray-200 my-2" />
+    <p>
+      AI and automation are only as good as the data powering them. We design and architect
+      <strong>robust, scalable data pipelines</strong> that ingest raw information and transform it
+      into <strong>high-quality, curated datasets</strong>. Whether preparing for advanced analytics
+      or feeding AI models, we ensure your <strong>data infrastructure</strong> is reliable, secure,
+      and ready to deliver real business value.
+    </p>
+    <h4>Key Deliverables</h4>
+    <ul>
+      <li><strong>Architecture design</strong></li>
+      <li><strong>Data integration</strong></li>
+      <li><strong>Production-ready curated data environments</strong></li>
+    </ul>
+  </article>
+</template>

--- a/composables/usePageMetadata.ts
+++ b/composables/usePageMetadata.ts
@@ -19,6 +19,21 @@ const routeMetadata: Record<string, { title: string; description: string }> = {
     description:
       'Explore our Data & AI services. From data strategy and GCP architecture to custom AI/ML solutions and Go backend development, we empower your business with data.',
   },
+  '/services/ai-automation-discovery': {
+    title: 'AI & Automation Strategic Discovery | ivmanto.com',
+    description:
+      'Discover high-impact AI and automation use-cases for your SMB. We audit workflows, pinpoint bottlenecks, and deliver an ROI-prioritized automation roadmap.',
+  },
+  '/services/data-pipeline-engineering': {
+    title: 'Data Pipeline Design & Architecture | ivmanto.com',
+    description:
+      'End-to-end data pipeline engineering — we design scalable, secure pipelines that transform raw data into curated, analytics- and AI-ready datasets.',
+  },
+  '/services/agentic-ai-solutions': {
+    title: 'Agentic AI Solution Design & Team Enablement | ivmanto.com',
+    description:
+      'Design and implement Agentic AI solutions — autonomous, reasoning agents — with architectural guidance, best practices, and team enablement for your staff.',
+  },
   '/services/data-strategy-and-governance': {
     title: 'Data Strategy & Governance | ivmanto.com',
     description:

--- a/data/services.ts
+++ b/data/services.ts
@@ -9,9 +9,79 @@ export type Service = {
   tagDetails?: { [key: string]: string }
   industries: string[]
   relatedBlogSlugs: string[]
+  featured?: boolean
+  keywords?: string[]
 }
 
 export const services: Service[] = [
+  {
+    id: 'ai-automation-discovery',
+    menuTitle: 'AI & Automation Discovery',
+    summary:
+      'Helping SMBs cut through the hype to identify high-impact, practical AI and automation use-cases — delivered as a clear, ROI-prioritized roadmap.',
+    icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />`,
+    detailsComponent: defineAsyncComponent(
+      () => import('~/components/services-content/AiAutomationDiscovery.vue'),
+    ),
+    industries: ['Retail', 'Professional Services', 'Manufacturing', 'Logistics'],
+    relatedBlogSlugs: [],
+    featured: true,
+    keywords: [
+      'AI use-case discovery',
+      'business process automation',
+      'workflow automation',
+      'automation roadmap',
+      'ROI prioritization',
+      'AI for SMBs',
+      'intelligent automation',
+    ],
+  },
+  {
+    id: 'data-pipeline-engineering',
+    menuTitle: 'Data Pipeline Engineering',
+    summary:
+      'Designing robust, scalable data pipelines that transform raw information into high-quality, curated datasets your analytics and AI models can trust.',
+    icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7" />`,
+    detailsComponent: defineAsyncComponent(
+      () => import('~/components/services-content/DataPipelineEngineering.vue'),
+    ),
+    industries: ['Finance', 'Healthcare', 'Retail', 'Technology'],
+    relatedBlogSlugs: ['VisionaryDataArchitecture', 'FromBigDataTo'],
+    featured: true,
+    keywords: [
+      'data pipeline engineering',
+      'data pipeline design',
+      'data architecture',
+      'data integration',
+      'ETL pipelines',
+      'curated datasets',
+      'AI-ready data',
+      'scalable data infrastructure',
+    ],
+  },
+  {
+    id: 'agentic-ai-solutions',
+    menuTitle: 'Agentic AI Solutions',
+    summary:
+      'Designing and implementing next-generation Agentic AI — autonomous, reasoning agents — alongside your engineering and product teams.',
+    icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h10.5a2.25 2.25 0 002.25-2.25V6.75a2.25 2.25 0 00-2.25-2.25H6.75A2.25 2.25 0 004.5 6.75v10.5a2.25 2.25 0 002.25 2.25zm.75-12h9v9h-9v-9z" />`,
+    detailsComponent: defineAsyncComponent(
+      () => import('~/components/services-content/AgenticAiSolutions.vue'),
+    ),
+    industries: ['Technology', 'Finance', 'Professional Services'],
+    relatedBlogSlugs: ['the-shift-to-agentic-ai-and-autonomous-workflows', 'TheRiseOfSlm'],
+    featured: true,
+    keywords: [
+      'agentic AI',
+      'AI agents',
+      'multi-agent systems',
+      'autonomous agents',
+      'agentic AI implementation',
+      'intelligent workflows',
+      'AI solution architecture',
+      'team enablement',
+    ],
+  },
   {
     id: 'principles',
     menuTitle: 'Guiding Principles',
@@ -67,7 +137,8 @@ export const services: Service[] = [
   {
     id: 'ml-engineering',
     menuTitle: 'AI & ML Solutions',
-    summary: 'Operationalizing machine learning models and developing your AI transformation strategy from prototype to production.',
+    summary:
+      'Operationalizing machine learning models and developing your AI transformation strategy from prototype to production.',
     icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2 1M4 7l2-1M4 7v2.5M12 21l-2-1m2 1l-2 1m2-1v-2.5M6 18l-2-1m2 1l-2 1m2-1V15M2 4h20M2 11h20M2 18h20" />`,
     detailsComponent: defineAsyncComponent(
       () => import('~/components/services-content/MlEngineering.vue'),
@@ -83,7 +154,8 @@ export const services: Service[] = [
   {
     id: 'data-strategy-and-governance',
     menuTitle: 'Data Governance',
-    summary: 'Implementing a robust data governance framework and DAMA-aligned principles for data quality and security.',
+    summary:
+      'Implementing a robust data governance framework and DAMA-aligned principles for data quality and security.',
     icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />`,
     detailsComponent: defineAsyncComponent(
       () => import('~/components/services-content/DataGovernance.vue'),
@@ -98,8 +170,7 @@ export const services: Service[] = [
 
 const servicesMap = new Map<string, Service>(services.map((service) => [service.id, service]))
 
-export function getServiceById(id: string | undefined): Service | undefined
-{
+export function getServiceById(id: string | undefined): Service | undefined {
   if (!id) return undefined
   return servicesMap.get(id)
 }

--- a/docs/features/dev-v0.1.3/release-notes.md
+++ b/docs/features/dev-v0.1.3/release-notes.md
@@ -1,0 +1,71 @@
+# Release dev-v0.1.3 — Featured Services & AI Search
+
+## Overview
+
+This release adds three new, prominently featured services to the Services
+section and makes them discoverable by traditional search engines and AI search
+engines through structured keywords and an expanded AI-search file set.
+
+## What shipped
+
+### 1. Three new featured services
+
+Added to `data/services.ts` and rendered first on `/services` with a "Featured"
+badge and amber accent styling:
+
+| Service | URL |
+|---|---|
+| AI & Automation Strategic Discovery | `/services/ai-automation-discovery` |
+| Data Pipeline Design & Architecture | `/services/data-pipeline-engineering` |
+| Agentic AI Solution Design & Team Enablement | `/services/agentic-ai-solutions` |
+
+Each has a full detail page (`/services/[id]`) with its own content component,
+relevant-industries list, per-page SEO metadata, and `Service` JSON-LD.
+
+The `Service` type gained two optional fields:
+
+- `featured` — drives the badge + accent treatment on the index grid.
+- `keywords` — a per-service keyword set (see below).
+
+### 2. Keyword indexing
+
+Each featured service has a curated keyword set, surfaced two ways so both
+traditional crawlers and AI search engines can pick it up:
+
+- In the `Service` JSON-LD `keywords` property (structured data).
+- As visible "Topics" tag pills on the service cards and detail pages.
+
+### 3. AI-search semantics
+
+- `Service` JSON-LD enriched with `keywords` and `category`.
+- `public/llms.txt` refreshed — the three new services are listed first.
+- New `public/llms-full.txt` — extended descriptions, key deliverables, and
+  topic keywords for all eight services, aimed at AI crawlers.
+
+## Files changed
+
+- `data/services.ts` — `Service` type fields + 3 new service entries
+- `components/services-content/` — 3 new detail content components
+- `pages/services/index.vue` — featured badge/accent + keyword tags
+- `pages/services/[id].vue` — per-service SEO, enriched JSON-LD, Topics sidebar
+- `composables/usePageMetadata.ts` — routes for the 3 new services
+- `public/llms.txt`, `public/llms-full.txt` — AI-search files
+
+## Verification
+
+- `npm run generate` — 102 routes prerendered, exit 0, no errors; all three
+  new service pages build.
+- Generated output checked: `sitemap.xml` includes all 8 service URLs;
+  detail-page JSON-LD carries `keywords` + `category`; featured CSS compiled.
+- Visual check of `/services` and a service detail page in the browser.
+
+## Known issues / follow-ups
+
+These are pre-existing and were not introduced by this release:
+
+- `npm run lint` fails — `eslint.config.ts` (flat config) requires ESLint 9,
+  but `package.json` pins ESLint 8.57. Formatting is handled by Prettier
+  (`npm run format`), which works.
+- Pages set no explicit `background-color`, so visitors with OS dark mode see
+  content pages rendered dark-on-dark. A single global background rule on
+  `html`/`body` resolves it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ivmanto.com",
-  "version": "0.0.16",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/pages/services/[id].vue
+++ b/pages/services/[id].vue
@@ -48,17 +48,34 @@
               <component :is="service.detailsComponent" />
             </main>
 
-            <!-- Right Sidebar: Keywords -->
+            <!-- Right Sidebar: Key Concepts & Topics -->
             <aside
-              v-if="service.tagDetails && Object.keys(service.tagDetails).length"
+              v-if="
+                (service.tagDetails && Object.keys(service.tagDetails).length) ||
+                service.keywords?.length
+              "
               class="w-full lg:w-1/3"
             >
-              <div class="p-4 bg-light-gray rounded-lg sticky top-24">
-                <h3 class="font-bold text-dark-slate mb-4">Key Concepts</h3>
-                <div class="space-y-4">
-                  <div v-for="(desc, tag) in service.tagDetails" :key="tag">
-                    <p class="font-semibold text-primary">{{ tag }}</p>
-                    <p class="text-sm text-gray-600">{{ desc }}</p>
+              <div class="p-4 bg-light-gray rounded-lg sticky top-24 space-y-6">
+                <div v-if="service.tagDetails && Object.keys(service.tagDetails).length">
+                  <h3 class="font-bold text-dark-slate mb-4">Key Concepts</h3>
+                  <div class="space-y-4">
+                    <div v-for="(desc, tag) in service.tagDetails" :key="tag">
+                      <p class="font-semibold text-primary">{{ tag }}</p>
+                      <p class="text-sm text-gray-600">{{ desc }}</p>
+                    </div>
+                  </div>
+                </div>
+                <div v-if="service.keywords?.length">
+                  <h3 class="font-bold text-dark-slate mb-3">Topics</h3>
+                  <div class="flex flex-wrap gap-2">
+                    <span
+                      v-for="keyword in service.keywords"
+                      :key="keyword"
+                      class="text-xs font-medium text-primary-dark bg-white border border-gray-200 rounded-full px-2.5 py-1"
+                    >
+                      {{ keyword }}
+                    </span>
                   </div>
                 </div>
               </div>
@@ -92,7 +109,9 @@
               >
                 <h4 class="font-semibold text-dark-slate">{{ article.title }}</h4>
                 <p class="text-sm text-gray-600 mt-1 line-clamp-2">{{ article.summary }}</p>
-                <span class="mt-2 inline-block text-primary font-semibold text-sm">Read: {{ article.title }} &rarr;</span>
+                <span class="mt-2 inline-block text-primary font-semibold text-sm"
+                  >Read: {{ article.title }} &rarr;</span
+                >
               </NuxtLink>
             </div>
           </div>
@@ -128,6 +147,21 @@ const relatedArticles = computed(() => {
 
 // Page-level SEO metadata
 const routeMetadata: Record<string, { title: string; description: string }> = {
+  'ai-automation-discovery': {
+    title: 'AI & Automation Strategic Discovery | ivmanto.com',
+    description:
+      'Discover high-impact AI and automation use-cases for your SMB. We audit workflows, pinpoint bottlenecks, and deliver an ROI-prioritized automation roadmap.',
+  },
+  'data-pipeline-engineering': {
+    title: 'Data Pipeline Design & Architecture | ivmanto.com',
+    description:
+      'End-to-end data pipeline engineering — we design scalable, secure pipelines that transform raw data into curated, analytics- and AI-ready datasets.',
+  },
+  'agentic-ai-solutions': {
+    title: 'Agentic AI Solution Design & Team Enablement | ivmanto.com',
+    description:
+      'Design and implement Agentic AI solutions — autonomous, reasoning agents — with architectural guidance, best practices, and team enablement for your staff.',
+  },
   'data-strategy-and-governance': {
     title: 'Data Strategy & Governance | ivmanto.com',
     description:
@@ -170,9 +204,11 @@ const serviceSchema = computed(() => {
     serviceType: service.value.menuTitle,
     name: service.value.menuTitle,
     description: service.value.summary,
+    category: 'Data & AI Consulting',
     provider: { '@id': 'https://ivmanto.com/#organization' },
     areaServed: { '@type': 'Country', name: 'Global' },
     url: `https://ivmanto.com${route.path}`,
+    ...(service.value.keywords?.length ? { keywords: service.value.keywords.join(', ') } : {}),
   }
 })
 

--- a/pages/services/index.vue
+++ b/pages/services/index.vue
@@ -51,10 +51,30 @@ useHead({
       <div
         v-for="service in allServices"
         :key="service.id"
-        class="flex flex-col rounded-lg border border-gray-200 shadow-sm p-6"
+        class="relative flex flex-col rounded-lg p-6"
+        :class="
+          service.featured
+            ? 'border-2 border-amber bg-amber/5 shadow-md'
+            : 'border border-gray-200 shadow-sm'
+        "
       >
+        <span
+          v-if="service.featured"
+          class="absolute -top-3 left-6 inline-flex items-center bg-amber text-white text-xs font-bold uppercase tracking-wide px-3 py-1 rounded-full shadow-sm"
+        >
+          Featured
+        </span>
         <h3 class="text-lg font-semibold text-dark-slate">{{ service.menuTitle }}</h3>
         <p class="mt-2 text-sm text-gray-600 flex-grow">{{ service.summary }}</p>
+        <div v-if="service.keywords?.length" class="mt-3 flex flex-wrap gap-1.5">
+          <span
+            v-for="keyword in service.keywords.slice(0, 4)"
+            :key="keyword"
+            class="text-xs text-primary-dark bg-light-gray border border-gray-200 rounded-full px-2 py-0.5"
+          >
+            {{ keyword }}
+          </span>
+        </div>
         <NuxtLink
           :to="`/services/${service.id}`"
           class="mt-4 inline-block text-primary font-semibold hover:underline"

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,83 @@
+# IVMANTO — Full Service & Site Reference
+
+> Expert Data & AI Consultancy on Google Cloud Platform (GCP). IVMANTO helps small and medium-sized businesses turn raw data into a strategic competitive advantage — from discovering practical AI use-cases to engineering data pipelines and deploying Agentic AI solutions.
+
+## About IVMANTO
+
+IVMANTO is a Data & AI consultancy founded and led by Nikolay Tonev, a Cloud Data Architect with 20+ years of enterprise data experience. The practice is a Google Cloud Platform specialist and grounds its work in the globally recognized DAMA-DMBOK (Data Management Body of Knowledge) standards. IVMANTO is based in Germany and serves clients worldwide.
+
+Contact: https://ivmanto.com/booking — book a free 30-minute discovery session.
+
+## Featured Services
+
+### AI & Automation Strategic Discovery
+
+URL: https://ivmanto.com/services/ai-automation-discovery
+
+Many small and medium-sized businesses want to leverage AI but don't know where to start. IVMANTO helps SMBs bypass the hype and identify high-impact, practical use-cases for automation. By auditing current workflows, IVMANTO pinpoints bottlenecks and designs a clear automation roadmap that directly reduces operational costs and scales business capabilities.
+
+Key deliverables: workflow assessments, ROI prioritization, actionable automation roadmaps.
+
+Topics: AI use-case discovery, business process automation, workflow automation, automation roadmap, ROI prioritization, AI for SMBs, intelligent automation.
+
+### Data Pipeline Design & Architecture
+
+URL: https://ivmanto.com/services/data-pipeline-engineering
+
+AI and automation are only as good as the data powering them. IVMANTO designs and architects robust, scalable data pipelines that ingest raw information and transform it into high-quality, curated datasets. Whether preparing for advanced analytics or feeding AI models, IVMANTO ensures data infrastructure is reliable, secure, and ready to deliver real business value.
+
+Key deliverables: architecture design, data integration, production-ready curated data environments.
+
+Topics: data pipeline engineering, data pipeline design, data architecture, data integration, ETL pipelines, curated datasets, AI-ready data, scalable data infrastructure.
+
+### Agentic AI Solution Design & Team Enablement
+
+URL: https://ivmanto.com/services/agentic-ai-solutions
+
+Going beyond basic chatbots, IVMANTO specializes in designing and implementing next-generation Agentic AI solutions — autonomous agents capable of executing complex tasks, reasoning, and collaborating. Working side-by-side with internal engineering or product teams, IVMANTO provides the architectural guidance, best practices, and implementation support needed to deploy intelligent workflows that deliver tangible business outcomes.
+
+Key deliverables: multi-agent system architecture, technical implementation guidance, team workshops.
+
+Topics: agentic AI, AI agents, multi-agent systems, autonomous agents, agentic AI implementation, intelligent workflows, AI solution architecture, team enablement.
+
+## Additional Services
+
+### Data Strategy & Governance
+
+URL: https://ivmanto.com/services/data-strategy-and-governance
+
+Implementing a robust data governance framework and DAMA-aligned principles for data quality and security. IVMANTO aligns data initiatives with business goals for maximum impact and regulatory compliance, including GDPR.
+
+### Data Architecture on GCP
+
+URL: https://ivmanto.com/services/data-architecture
+
+Designing and building scalable, secure, and cost-effective data architectures on Google Cloud Platform. IVMANTO leverages BigQuery, Cloud Storage, Cloud SQL, and modern data engineering practices such as the lakehouse, data mesh, and data fabric.
+
+### AI & ML Solutions
+
+URL: https://ivmanto.com/services/ml-engineering
+
+Operationalizing machine learning models and developing an AI transformation strategy from prototype to production. IVMANTO builds automated CI/CD pipelines for model training, deployment, and monitoring using Vertex AI.
+
+### Sovereign Cloud
+
+URL: https://ivmanto.com/services/sovereigncloud
+
+An architectural perspective on Data, Operations, and AI Sovereignty for compliance-sensitive environments, aligned with the EU Data Act.
+
+### Guiding Principles
+
+URL: https://ivmanto.com/services/principles
+
+DAMA-aligned principles for data strategy, governance, and architecture, grounded in the DAMA-DMBOK, ensuring data becomes a reliable and valuable asset for decision-making and AI.
+
+## Key Pages
+
+- Home — https://ivmanto.com/ — Overview of IVMANTO's Data & AI consultancy services.
+- About — https://ivmanto.com/about — Background on founder Nikolay Tonev, Cloud Data Architect & AI Consultant.
+- Blog — https://ivmanto.com/blog — Articles on data strategy, cloud architecture, AI/ML, Agentic AI, and software engineering.
+- Assessment — https://ivmanto.com/assessment — Data & AI readiness assessment.
+- Book a Consultation — https://ivmanto.com/booking — Schedule a free 30-minute discovery session.
+- Privacy Policy — https://ivmanto.com/privacy-policy — GDPR-compliant data handling policy.
+- Terms of Service — https://ivmanto.com/terms — Terms governing use of ivmanto.com.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,11 +1,14 @@
 # IVMANTO
 
-> Expert Data & AI Consultancy on Google Cloud Platform. IVMANTO helps businesses design scalable data architectures, implement AI/ML solutions, and establish data governance frameworks — turning raw data into a strategic competitive advantage.
+> Expert Data & AI Consultancy on Google Cloud Platform. IVMANTO helps businesses discover practical AI and automation use-cases, engineer end-to-end data pipelines, design and implement Agentic AI solutions, build scalable data architectures, and establish data governance frameworks — turning raw data into a strategic competitive advantage.
 
 Founded and led by Nikolay Tonev, a Cloud Data Architect with 20+ years of enterprise data experience and a GCP specialist aligned with DAMA-DMBOK principles.
 
 ## Services
 
+- [AI & Automation Strategic Discovery](https://ivmanto.com/services/ai-automation-discovery): Helping SMBs identify high-impact, practical AI and automation use-cases through workflow assessments, ROI prioritization, and actionable automation roadmaps.
+- [Data Pipeline Design & Architecture](https://ivmanto.com/services/data-pipeline-engineering): End-to-end data pipeline engineering — scalable, secure pipelines that transform raw data into curated, analytics- and AI-ready datasets.
+- [Agentic AI Solution Design & Team Enablement](https://ivmanto.com/services/agentic-ai-solutions): Designing and implementing Agentic AI — autonomous, reasoning agents — with multi-agent architecture, implementation guidance, and team workshops.
 - [Data Strategy & Governance](https://ivmanto.com/services/data-strategy-and-governance): Aligning data initiatives with business goals; governance frameworks for GDPR and compliance.
 - [Data Architecture on GCP](https://ivmanto.com/services/data-architecture): Scalable, secure data architectures using BigQuery, Cloud Storage, and modern data engineering.
 - [AI & ML Solutions](https://ivmanto.com/services/ml-engineering): Custom AI/ML pipelines, predictive analytics, and generative AI on Google Cloud.
@@ -20,3 +23,7 @@ Founded and led by Nikolay Tonev, a Cloud Data Architect with 20+ years of enter
 - [Book a Consultation](https://ivmanto.com/booking): Schedule a free 30-minute discovery session.
 - [Privacy Policy](https://ivmanto.com/privacy-policy): GDPR-compliant data handling policy.
 - [Terms of Service](https://ivmanto.com/terms): Terms governing use of ivmanto.com.
+
+## Optional
+
+- [Full service reference](https://ivmanto.com/llms-full.txt): Extended descriptions, key deliverables, and topic keywords for every service.


### PR DESCRIPTION
## Summary

Bundles the **dev-v0.1.3** working branch for merge to `main`.

**Featured services & AI search** (primary feature)
- Three new featured services on `/services` — AI & Automation Strategic Discovery, Data Pipeline Design & Architecture, and Agentic AI Solution Design & Team Enablement — shown first with a "Featured" badge and accent styling, each with a full detail page.
- Per-service keyword sets exposed via `Service` JSON-LD `keywords` and visible "Topics" tags, for search-engine and AI-crawler discovery.
- `Service` JSON-LD enriched with `keywords` + `category`; `llms.txt` refreshed and a new `llms-full.txt` added.

**Also on this branch**
- `fix(seo)`: remove `www.ivmanto.com` self-links in the privacy policy.
- `docs`: add `CLAUDE.md` project guidance.
- `chore(backend)`: DWD + Google Meet smoke-test script.
- `chore(release)`: dev-v0.1.3 release notes, README refresh, version bump to `0.1.3`.

Full detail: `docs/features/dev-v0.1.3/release-notes.md`.

## Test plan

- [x] `npm run generate` — 102 routes prerendered, exit 0, no errors
- [x] All 3 new service pages prerender; `sitemap.xml` lists all 8 service URLs
- [x] Detail-page JSON-LD carries `keywords` + `category`
- [x] Visual check of `/services` and a service detail page
- [ ] Branch-protection / CI checks pass on this PR
- [ ] Spot-check the Cloud Run deployment after merge

## Known follow-ups (pre-existing, not introduced here)

- `npm run lint` fails — `eslint.config.ts` (flat config) needs ESLint 9, but ESLint 8.57 is pinned.
- No explicit page `background-color` — OS dark-mode visitors see content pages dark-on-dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)