### PR TITLE
chore(agents): add AGENTS.md, PR template, and peer-review contract

### DIFF
--- a/.agents/pr-review-contract.md
+++ b/.agents/pr-review-contract.md
@@ -1,0 +1,61 @@
+# PR review contract
+
+This file describes what the reviewer agent (Claude) checks on every PR opened against `main`. It is the bar an agent author can expect to be held to.
+
+## What gets reviewed
+
+Every PR receives a structured review covering:
+
+1. **STRICT rules** — the 6 STRICT rules in [.agents/rules.md](.agents/rules.md): content preservation, blog system integrity, booking system integrity, cookie-consent gating, no unauthorised changes, API proxy pattern.
+2. **Pre-PR checklist** — was lint / test / build / generate evidence included in the PR body? If not, the review blocks until the author re-runs and pastes output.
+3. **Secret hygiene** — the diff is scanned for committed secrets (passwords, API keys, OAuth secrets, JWT signing keys, GA API secret, SMTP creds).
+4. **Scope** — does the diff stay within the stated task scope, or did the author quietly refactor unrelated files?
+5. **Code correctness** — logic, error handling, edge cases on the changed paths.
+6. **Code quality** — readability, naming, dead code, duplicated logic. Flagged as comments, not blocks.
+
+## Block bar — review requests changes
+
+The PR is blocked if any of these hold:
+
+- A STRICT rule from `.agents/rules.md` is violated.
+- A secret value (real password, API key, OAuth secret, JWT signing key, GA API secret, SMTP creds) is committed.
+- `cloudbuild.yaml`, `backend/internal/gcal/` auth code, `backend/cmd/server/main.go` startup contract, Secret Manager references, or cookie-consent gating is touched without the task explicitly calling for it.
+- Frontend PR without evidence that `npm run lint` and `npm run generate` pass.
+- Backend PR without evidence that `go build ./...` and `go test ./...` pass.
+- Commit messages don't follow the conventional-commits style used in `git log` (e.g. `feat(services): ...`, `fix(seo): ...`).
+- The branch is not `dev-vX.Y.Z` merging into `main`.
+- A correctness bug is identified.
+
+## Comment-only — does not block
+
+- Naming, style, readability suggestions.
+- Out-of-scope cleanups (flagged with `[SCOPE]` tag — the author should split into a separate PR).
+- Missing tests where the package has an existing test pattern — flagged but not blocked unless the change is high-risk (auth, payments, booking, deploy).
+- Documentation suggestions.
+
+## What the reviewer will not do
+
+- Merge the PR — that decision stays with the human owner.
+- Push commits directly to the PR branch — feedback comes as PR comments only.
+- Approve a PR with a flagged STRICT-rule violation, even if the author asks. The owner can override by merging directly.
+
+## Review output format
+
+For every PR the reviewer leaves:
+
+1. **Summary line** — one of:
+   - `✅ Looks good — no blockers` (may still include `[STYLE]` suggestions)
+   - `⚠️ Needs changes — N blockers` (lists the blockers up top)
+   - `🚧 Out of scope — needs owner triage` (when the PR mixes scopes or the task isn't in `tasks/todo.md`)
+2. **Inline comments** on specific lines, tagged with the issue category:
+   - `[STRICT]` — STRICT-rule violation (blocking)
+   - `[BUG]` — correctness issue (blocking)
+   - `[SECRET]` — secret in diff (blocking)
+   - `[SCOPE]` — out of scope (comment-only)
+   - `[STYLE]` — style/readability (comment-only)
+   - `[TEST]` — missing test coverage (usually comment-only)
+3. **Pre-PR checklist verification** — confirms which items were evidenced in the PR body and which were missing.
+
+## Re-review on changes
+
+When the PR author pushes new commits to address feedback, the reviewer re-runs the contract against the new diff. A blocking comment is only resolved when the underlying issue is fixed — not when the author replies "done".

--- a/.agents/rules.md
+++ b/.agents/rules.md
@@ -367,6 +367,20 @@ The Dockerfile currently uses `serve -s .` for the SPA. For pure SSG (no ISR), t
 - **Type Safety**: Strict TypeScript — no `any` unless unavoidable
 - **Content Sanitization**: Always use DOMPurify for user/API-provided HTML (`v-html`)
 
+### Backend (Go)
+- **Style**: Standard Go formatting (`gofmt`). No custom linter beyond `go vet`.
+- **Module path**: `ivmanto.com/backend`. Internal packages live under `backend/internal/`.
+- **Handlers**: Each domain (booking, blog, contact, ideas) has its own package in `backend/internal/` exporting an HTTP handler. Routes are registered in `backend/cmd/server/main.go`.
+- **Env vars**: All env vars are loaded by `internal/config` at startup. Missing required vars cause a fatal exit logged as `"missing required environment variables"`. When you add a new env var:
+  1. Wire it into `internal/config/config.go` (load + validate)
+  2. Add a placeholder to `backend/.env.example`
+  3. Add the substitution to `cloudbuild.yaml` OR add it to Secret Manager — state which in the PR
+- **Error handling**: Wrap errors with context (`fmt.Errorf("doing X: %w", err)`). HTTP handlers respond with non-2xx + JSON body `{"error": "..."}` — do not panic.
+- **Logging**: Use the structured logger middleware (`internal/middleware`). For ad-hoc logs use `log.Printf` with `key=value` pairs. No `fmt.Println` in handler code.
+- **External clients**: GCS, Vertex AI, Calendar, SMTP clients are initialised once in `main.go` and injected into handlers. Do not create new clients per request.
+- **Calendar / Meet**: All Google Calendar work goes through `internal/gcal`. Meet conferences require `ConferenceDataVersion(1)` on the Calendar update call. DWD impersonation is non-negotiable — do not switch to a different auth strategy without owner approval.
+- **Tests**: Place tests next to the package (`foo_test.go`). Mock GCP clients via interfaces where already abstracted (see `internal/gcal` for the pattern). Don't add new test frameworks.
+
 ### SEO Standards
 - Every page MUST have a unique `<title>` and `<meta name="description">`
 - Pages not meant for indexing MUST have `<meta name="robots" content="noindex">`

--- a/.agents/workflows/development.md
+++ b/.agents/workflows/development.md
@@ -43,3 +43,37 @@ description: Workflow Orchestration
 
 ### Common Commands
 
+Frontend:
+- `npm run dev` — dev server on :3000, proxies `/api/*` to :8080
+- `npm run lint` — ESLint with auto-fix
+- `npm run format` — Prettier
+- `npm run generate` — SSG build (what Cloud Build runs)
+- `npm run preview` — preview the generated site
+
+Backend:
+- `cd backend && go run ./cmd/server` — start API on :8080
+- `go build ./...` — compile all packages
+- `go test ./...` — run all tests
+- `go test ./internal/gcal/...` — run a single package's tests
+- `go vet ./...` — static analysis
+
+GCP (local dev):
+- `gcloud auth application-default login` — set up ADC for the local Go binary
+- `gcloud auth application-default set-quota-project ivmanto-com-prod` — set the project ADC will bill
+
+### Typical dev loop
+
+1. Pull `main`, branch `dev-vX.Y.Z` matching the next version in `package.json`.
+2. Add your plan to `tasks/todo.md`. Wait for owner approval before implementing.
+3. Implement minimally per `.agents/rules.md`.
+4. Run the relevant verification commands above.
+5. Commit using conventional-commits style (see `git log --oneline` for examples).
+6. Open a PR against `main` with `.github/pull_request_template.md` filled in.
+7. Address review feedback. Re-run verification on any new commits.
+
+### Debugging tips
+
+- Backend won't start? Check the log for `"missing required environment variables"` — that's `internal/config` telling you to update `backend/.env`.
+- Frontend `/api/*` calls fail in dev? Confirm the backend is running on :8080 — the Nuxt dev proxy expects it.
+- Calendar API 401 / 403? DWD impersonation needs the SA's OAuth client ID authorised in Workspace Admin Console with scope `https://www.googleapis.com/auth/calendar`. Don't change the auth strategy to "fix" this.
+- Cloud Run deploys but blog/booking returns 5xx? Check Secret Manager values are present and the Cloud Build trigger references them.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+## Summary
+
+<!-- 1–3 sentences: what changed and why. Focus on the why; the diff shows the what. -->
+
+## Type & scope
+
+<!-- One conventional-commits type and one scope, matching git log:
+     type:  feat | fix | chore | docs | refactor | test | perf
+     scope: services | seo | backend | blog | booking | frontend | release | ...  -->
+
+- Type:
+- Scope:
+
+## Linked task
+
+<!-- Path to the entry in tasks/todo.md, or issue/PR link. -->
+
+## Pre-PR checklist
+
+**Frontend changes** (delete this block if not applicable):
+- [ ] `npm run lint` passes — paste last 5 lines of output:
+  ```
+  ```
+- [ ] `npm run generate` passes — paste last 5 lines of output:
+  ```
+  ```
+- [ ] Verified affected page(s) in the browser via `npm run dev`
+
+**Backend changes** (delete this block if not applicable):
+- [ ] `go build ./...` passes
+- [ ] `go test ./...` passes — paste last 5 lines of output:
+  ```
+  ```
+- [ ] `go run ./cmd/server` boots locally with no new missing-env-var errors
+
+**Always:**
+- [ ] No secrets in the diff (`*_PASS`, `*_SECRET`, `*_KEY`, `*_TOKEN`, OAuth, JWT)
+- [ ] No unintended changes to `cloudbuild.yaml`, `backend/internal/gcal/`, `backend/cmd/server/main.go` startup, Secret Manager refs, or cookie-consent gating
+- [ ] Commit messages follow conventional-commits style (`type(scope): summary`)
+- [ ] Branch is `dev-vX.Y.Z`
+
+## New env vars / secrets
+
+<!-- If this PR adds env vars, name them here. Confirm each:
+     - placeholder in backend/.env.example
+     - destination: cloudbuild.yaml substitution OR Secret Manager
+     The owner provisions Secret Manager values before the deploy. -->
+
+None.
+
+## Notes / risks for the reviewer
+
+<!-- Anything the reviewer should pay extra attention to: tricky logic, areas you weren't sure about, follow-ups deferred to another PR. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# Agents working in this repository
+
+This file is the entrypoint for any AI agent (Claude, Cursor, Codex, or other) opening a task in this repo. Humans should read `README.md` first.
+
+## Required reading, in order
+
+1. `README.md` — repo layout & quickstart
+2. `CLAUDE.md` — architecture, request flow, deployment
+3. `.agents/rules.md` — STRICT rules, file layout, frontend and backend code standards
+4. `.agents/workflows/development.md` — dev loop, common commands, debugging tips
+5. `.agents/pr-review-contract.md` — what the reviewer will check on your PR
+
+If you skip any of these you will produce a PR that gets blocked. Read them first.
+
+## Branching & commits
+
+- Working branch: `dev-vX.Y.Z`, matching the next version in `package.json`. Never push directly to `main`. Branch protection enforces this.
+- Conventional commits, lowercase, scoped. Examples from `git log`:
+  - `feat(services): add 3 featured services with keyword indexing`
+  - `fix(seo): remove www.ivmanto.com self-links in privacy policy`
+  - `chore(release): prep dev-v0.1.3 — release notes, README, version bump`
+  - `docs: track CLAUDE.md project guidance for Claude Code`
+- One logical change per PR. Don't bundle unrelated refactors. If you spot something off-task, flag it in the PR body — don't fix it silently.
+
+## Pre-PR checklist (include evidence in the PR body)
+
+Frontend changes:
+- [ ] `npm run lint` passes
+- [ ] `npm run generate` passes
+- [ ] Verified affected page(s) in the browser via `npm run dev`
+
+Backend changes:
+- [ ] `go build ./...` passes
+- [ ] `go test ./...` passes
+- [ ] `go run ./cmd/server` boots — no new missing-env-var errors
+
+Both:
+- [ ] No secrets in the diff (scan for: passwords, API keys, OAuth secrets, JWT signing keys, GA API secret, SMTP creds)
+- [ ] No changes to `cloudbuild.yaml`, auth/DWD code, or Secret Manager references unless the task explicitly calls for them
+- [ ] PR description states what changed and why (1–3 sentences)
+
+## Secrets
+
+NEVER commit:
+- `backend/.env` (it's gitignored — keep it that way)
+- Real values for any `*_PASS`, `*_SECRET`, `*_KEY`, `*_TOKEN` env var
+- OAuth client IDs, JWT signing keys, API keys (Gemini, GA API secret, SMTP)
+
+Production secrets come from Secret Manager (project: `ivmanto-com-prod`), injected by Cloud Build into Cloud Run at deploy time. Local dev secrets go in `backend/.env` (gitignored).
+
+If your task needs a new secret:
+1. Name the new env var in the PR description.
+2. Add a placeholder to `backend/.env.example`.
+3. The human owner adds the real value to Secret Manager + Cloud Build trigger before the deploy.
+
+## Do not touch without explicit task scope
+
+If the task description does not name one of these, leave it alone. If it seems unavoidable, stop and ask the owner.
+
+- `cloudbuild.yaml` — deploys both services
+- `backend/internal/gcal/` — DWD impersonation / Meet conference setup
+- `backend/cmd/server/main.go` startup contract — env-var loading and client initialisation order
+- `nuxt.config.ts` runtime config / build hooks
+- `plugins/analytics.client.ts` — cookie-consent gating
+- The `dist` symlink at repo root (points into `.output/public`)
+- Secret Manager values (out of repo)
+
+## Standard workflow
+
+1. **Plan** — write the task to `tasks/todo.md` per `.agents/rules.md`. Wait for owner approval before implementing.
+2. **Implement** — keep changes minimal. Follow the file layout in `CLAUDE.md` and the conventions in `.agents/rules.md`.
+3. **Verify** — run the pre-PR checklist above. Paste the command output into your PR body.
+4. **PR** — open against `main`. Fill in `.github/pull_request_template.md`. Link to the `tasks/todo.md` entry.
+5. **Review** — Claude reviews using `.agents/pr-review-contract.md`. Address feedback or push back with reasoning.
+6. **Merge** — the human owner merges. Reviewers do not merge.
+
+## When unsure
+
+- Re-read the STRICT section of `.agents/rules.md`.
+- Check `CLAUDE.md` for architecture context.
+- Browse `docs/` for feature history.
+- Ask the owner via a PR comment — don't guess on auth, deployment, or architectural questions.


### PR DESCRIPTION
## Summary

Establishes the entrypoint and conventions for AI agents working in this repo, so a new agent (e.g. Ivmo) can clone the repo and know exactly what to read, what to avoid, how to open a PR, and what bar peer review holds them to.

- **New `AGENTS.md`** at root — single agent-agnostic entrypoint; branching (`dev-vX.Y.Z`), commit style, secrets, do-not-touch list, pre-PR checklist
- **New `.agents/pr-review-contract.md`** — what the reviewer checks on every PR, the block bar (STRICT-rule violations, secrets in diff, untouched-without-scope edits to `cloudbuild.yaml` / auth / Secret Manager / consent gating, failed lint/build/test, bad branching), and the output format with `[STRICT]` / `[BUG]` / `[SECRET]` / `[SCOPE]` / `[STYLE]` / `[TEST]` tags
- **New `.github/pull_request_template.md`** — forces lint/test/build evidence in every PR body
- **`.agents/rules.md`** — adds a Backend (Go) conventions section (handler placement, env-var startup contract, gcal/DWD rule, logging, tests)
- **`.agents/workflows/development.md`** — completes the previously truncated `### Common Commands` section with the full dev loop, command reference, and debugging tips

## Type & scope

- Type: chore
- Scope: agents

## Pre-PR checklist

Docs-only change. No code touched, so build/test/lint are not impacted.

- [x] No secrets in the diff
- [x] No changes to `cloudbuild.yaml`, `backend/internal/gcal/`, `backend/cmd/server/main.go` startup, Secret Manager refs, or cookie-consent gating
- [x] Commit message follows conventional-commits style
- [x] Branch is `dev-v0.1.4`

## Notes

- AGENTS.md links resolve to existing files: `CLAUDE.md`, `README.md`, `.agents/rules.md`, `.agents/workflows/development.md`, `.agents/pr-review-contract.md`.
- No version bump in `package.json` — that happens at release prep, not at the kickoff of a `dev-v0.1.X` cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)