### PR TITLE
feat(footer): add muchakova.com to Friends section

### DIFF
--- a/components/layout/TheFooter.vue
+++ b/components/layout/TheFooter.vue
@@ -36,6 +36,7 @@
           <p class="text-white font-semibold text-sm tracking-widest uppercase mt-6 mb-3">Friends</p>
           <div class="flex flex-col space-y-2 text-sm">
             <a href="https://vivily.de/" target="_blank" rel="noopener noreferrer" class="hover:text-amber transition-colors">Vivily.de</a>
+            <a href="https://muchakova.com/" target="_blank" rel="noopener noreferrer" class="hover:text-amber transition-colors">Muchakova.com</a>
           </div>
         </div>
       </div>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -551,3 +551,51 @@ Start with **Option A** (pure client-side blog). This achieves the primary goal 
 | All `src/services/` | `services/` (moved, not deleted) |
 | All `src/data/` | `data/` (moved, not deleted) |
 | All `src/types/` | `types/` (moved, not deleted) |
+
+---
+
+## Task: 2026-06-04 — Add muchakova.com to site footer Friends section
+
+**Branch:** `dev-v0.1.5` (off `main`, current HEAD `ede9113`)
+**Scope:** Frontend — one file, one new `<a>` element in the Friends block.
+**Owner-asked:** Yes (2026-06-04).
+
+### Plan
+
+- [x] Read `AGENTS.md` and `.agents/rules.md` (rule book)
+- [x] Locate footer component (`components/layout/TheFooter.vue`) and confirm Friends block
+- [x] Match existing pattern from Vivily.de entry (trailing slash, `hover:text-amber`, `target="_blank" rel="noopener noreferrer"`)
+- [x] Cut branch `dev-v0.1.5` from `main`
+- [x] Add entry to `tasks/todo.md`
+- [ ] Add `<a href="https://muchakova.com/" ...>Muchakova.com</a>` directly below Vivily.de line
+- [ ] Commit: `feat(footer): add muchakova.com to Friends section`
+- [ ] Push branch to `origin`
+- [ ] Open PR against `main` using `.github/pull_request_template.md`
+- [ ] **Pre-PR frontend gates deferred to CI for this PR only** (local npm env not yet configured on this box — see Note A below)
+
+### Verification
+
+- [ ] Diff review against the existing Vivily.de line for pattern consistency
+- [ ] CI `npm run lint` and `npm run generate` pass on the PR
+- [ ] Manual footer check on the preview environment post-merge
+
+### Note A — Local verification deferred
+
+Per owner direction (2026-06-04), local `npm install` / `lint` / `generate` are intentionally not run for this PR. Reason: local node/npm environment is not yet bootstrapped on the workstation. This is acceptable for a 1-line content change in a Vue template (no logic, no env vars, no build-config touch). A separate setup task will bootstrap the local frontend dev environment so future PRs can be verified locally before reaching PROD CI/CD.
+
+### Note B — Out of scope (do not touch in this PR)
+
+- `cloudbuild.yaml`
+- `nuxt.config.ts`
+- `plugins/analytics.client.ts`
+- `dist` symlink
+- Anything in `backend/`
+- Any secret / env var
+
+### Out-of-scope issues flagged (NOT to be fixed in this PR)
+
+None observed in the Friends block.
+
+### Lessons
+
+(none yet — will fill in after review)


### PR DESCRIPTION
Add a second entry in the site footer's Friends block matching the existing Vivily.de pattern (trailing slash, hover:text-amber, target=_blank rel=noopener noreferrer). One-line content change; no logic, no build config, no env vars.

Tasks tracker entry appended to tasks/todo.md per .agents/rules.md. Local frontend verification deferred to CI for this PR (local npm env not yet bootstrapped on workstation) - acceptable for a content-only change; will be set up as a separate task.

Ref: tasks/todo.md -> 'Task: 2026-06-04 - Add muchakova.com to site footer'

## Summary

<!-- 1–3 sentences: what changed and why. Focus on the why; the diff shows the what. -->

## Type & scope

<!-- One conventional-commits type and one scope, matching git log:
     type:  feat | fix | chore | docs | refactor | test | perf
     scope: services | seo | backend | blog | booking | frontend | release | ...  -->

- Type:
- Scope:

## Linked task

<!-- Path to the entry in tasks/todo.md, or issue/PR link. -->

## Pre-PR checklist

**Frontend changes** (delete this block if not applicable):
- [ ] `npm run lint` passes — paste last 5 lines of output:
  ```
  ```
- [ ] `npm run generate` passes — paste last 5 lines of output:
  ```
  ```
- [ ] Verified affected page(s) in the browser via `npm run dev`

**Backend changes** (delete this block if not applicable):
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes — paste last 5 lines of output:
  ```
  ```
- [ ] `go run ./cmd/server` boots locally with no new missing-env-var errors

**Always:**
- [ ] No secrets in the diff (`*_PASS`, `*_SECRET`, `*_KEY`, `*_TOKEN`, OAuth, JWT)
- [ ] No unintended changes to `cloudbuild.yaml`, `backend/internal/gcal/`, `backend/cmd/server/main.go` startup, Secret Manager refs, or cookie-consent gating
- [ ] Commit messages follow conventional-commits style (`type(scope): summary`)
- [ ] Branch is `dev-vX.Y.Z`

## New env vars / secrets

<!-- If this PR adds env vars, name them here. Confirm each:
     - placeholder in backend/.env.example
     - destination: cloudbuild.yaml substitution OR Secret Manager
     The owner provisions Secret Manager values before the deploy. -->

None.

## Notes / risks for the reviewer

<!-- Anything the reviewer should pay extra attention to: tricky logic, areas you weren't sure about, follow-ups deferred to another PR. -->
