### PR TITLE
feat(booking): replace day-stepper with month-grid calendar view

### DIFF
--- a/components/booking/CalendarMonthGrid.vue
+++ b/components/booking/CalendarMonthGrid.vue
@@ -75,8 +75,8 @@ const grid = computed(() => buildMonthGrid(displayMonth.value))
 
 const isPrevMonthDisabled = computed(() => {
   const firstOfDisplay = new Date(displayMonth.value.getFullYear(), displayMonth.value.getMonth(), 1)
-  const firstOfThisMonth = new Date(today.getFullYear(), today.getMonth(), 1)
-  return firstOfDisplay.getTime() <= firstOfThisMonth.getTime()
+  const firstOfMinMonth = new Date(minDate.value.getFullYear(), minDate.value.getMonth(), 1)
+  return firstOfDisplay.getTime() <= firstOfMinMonth.getTime()
 })
 
 const isNextMonthDisabled = computed(() => {

--- a/components/booking/CalendarMonthGrid.vue
+++ b/components/booking/CalendarMonthGrid.vue
@@ -80,10 +80,10 @@ const isPrevMonthDisabled = computed(() => {
 })
 
 const isNextMonthDisabled = computed(() => {
-  const lastOfDisplay = new Date(displayMonth.value.getFullYear(), displayMonth.value.getMonth() + 1, 0)
-  const maxMonth = new Date(maxDate.value.getFullYear(), maxDate.value.getMonth(), 1)
-  return lastOfDisplay.getFullYear() > maxMonth.getFullYear()
-    || (lastOfDisplay.getFullYear() === maxMonth.getFullYear() && lastOfDisplay.getMonth() > maxMonth.getMonth())
+  const d = displayMonth.value
+  const m = maxDate.value
+  return d.getFullYear() > m.getFullYear()
+    || (d.getFullYear() === m.getFullYear() && d.getMonth() >= m.getMonth())
 })
 
 const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']

--- a/components/booking/CalendarMonthGrid.vue
+++ b/components/booking/CalendarMonthGrid.vue
@@ -1,0 +1,183 @@
+<script setup lang="ts">
+import { buildMonthGrid, isSameDay, clampDate } from '~/composables/useDate'
+
+/**
+ * Month-grid date picker used by the booking page. Renders a 6×7 grid of
+ * days for the currently displayed month (with out-of-month padding days as
+ * inert cells) and lets visitors jump between months and select a day.
+ *
+ * Selection is two-way bound via v-model:modelValue. The parent's
+ * `selectedDate` is the source of truth — this component only holds an
+ * internal `displayMonth` ref for the month currently being viewed, which
+ * is initialised from `modelValue` and does NOT change `selectedDate` when
+ * the visitor navigates months. Only a day click updates the bound date.
+ *
+ * Bounds: cells outside [minDate, maxDate] are rendered as disabled. The
+ * prev-month button is disabled when `displayMonth` is the current month;
+ * the next-month button is disabled when `displayMonth` is the month
+ * containing `maxDate`.
+ */
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: Date
+    minDate?: Date
+    maxDate?: Date
+    disabled?: boolean
+  }>(),
+  {
+    minDate: undefined,
+    maxDate: undefined,
+    disabled: false,
+  },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [Date]
+}>()
+
+// Effective bounds: today and today+30 by default. The parent normally
+// passes these explicitly; the defaults are here so the component can be
+// rendered standalone (Storybook / preview) without surprises.
+const today = new Date()
+const minDate = computed(() => props.minDate ?? new Date(today.getFullYear(), today.getMonth(), today.getDate()))
+const maxDate = computed(() => {
+  if (props.maxDate) return props.maxDate
+  const d = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+  d.setDate(d.getDate() + 30)
+  return d
+})
+
+// Internal month being shown. Initialised from the bound value. Prev/next
+// arrows only mutate this ref, never modelValue.
+const displayMonth = ref(new Date(props.modelValue.getFullYear(), props.modelValue.getMonth(), 1))
+
+// Today (midnight) — used for the "today" ring on the cell. Captured once at
+// component setup so the ring stays put as the wall clock advances during a
+// long session.
+const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+
+// If the bound value jumps to a different month (e.g. parent reset), realign.
+watch(
+  () => props.modelValue,
+  (v) => {
+    if (v.getFullYear() !== displayMonth.value.getFullYear() || v.getMonth() !== displayMonth.value.getMonth()) {
+      displayMonth.value = new Date(v.getFullYear(), v.getMonth(), 1)
+    }
+  },
+)
+
+const monthLabel = computed(() =>
+  displayMonth.value.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }),
+)
+
+const grid = computed(() => buildMonthGrid(displayMonth.value))
+
+const isPrevMonthDisabled = computed(() => {
+  const firstOfDisplay = new Date(displayMonth.value.getFullYear(), displayMonth.value.getMonth(), 1)
+  const firstOfThisMonth = new Date(today.getFullYear(), today.getMonth(), 1)
+  return firstOfDisplay.getTime() <= firstOfThisMonth.getTime()
+})
+
+const isNextMonthDisabled = computed(() => {
+  const lastOfDisplay = new Date(displayMonth.value.getFullYear(), displayMonth.value.getMonth() + 1, 0)
+  const maxMonth = new Date(maxDate.value.getFullYear(), maxDate.value.getMonth(), 1)
+  return lastOfDisplay.getFullYear() > maxMonth.getFullYear()
+    || (lastOfDisplay.getFullYear() === maxMonth.getFullYear() && lastOfDisplay.getMonth() > maxMonth.getMonth())
+})
+
+const dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+function inCurrentMonth(d: Date): boolean {
+  return d.getMonth() === displayMonth.value.getMonth()
+}
+
+function isDisabledCell(d: Date): boolean {
+  return !isSameDay(d, minDate.value) && d.getTime() < minDate.value.getTime()
+    || d.getTime() > maxDate.value.getTime()
+}
+
+function selectDay(d: Date) {
+  if (props.disabled) return
+  if (isDisabledCell(d)) return
+  // Clamp to bounds just in case (defensive — UI should already enforce).
+  const clamped = clampDate(d, minDate.value, maxDate.value)
+  emit('update:modelValue', clamped)
+}
+
+function shiftMonth(amount: number) {
+  if (amount < 0 && isPrevMonthDisabled.value) return
+  if (amount > 0 && isNextMonthDisabled.value) return
+  const next = new Date(displayMonth.value.getFullYear(), displayMonth.value.getMonth() + amount, 1)
+  displayMonth.value = next
+}
+</script>
+
+<template>
+  <div class="w-full" :class="{ 'opacity-60 pointer-events-none': disabled }">
+    <!-- Month header + nav -->
+    <div class="flex items-center justify-between mb-3">
+      <button
+        type="button"
+        @click="shiftMonth(-1)"
+        class="btn-day-nav"
+        :disabled="isPrevMonthDisabled"
+        aria-label="Previous month"
+      >
+        <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+        </svg>
+      </button>
+      <h3 class="text-lg font-semibold text-gray-700">{{ monthLabel }}</h3>
+      <button
+        type="button"
+        @click="shiftMonth(1)"
+        class="btn-day-nav"
+        :disabled="isNextMonthDisabled"
+        aria-label="Next month"
+      >
+        <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Day-of-week header -->
+    <div class="grid grid-cols-7 gap-1 mb-1">
+      <div v-for="d in dayLabels" :key="d" class="text-center text-xs font-medium text-gray-500">
+        {{ d }}
+      </div>
+    </div>
+
+    <!-- Day grid -->
+    <div class="grid grid-cols-7 gap-1">
+      <template v-for="(cell, idx) in grid" :key="idx">
+        <button
+          v-if="inCurrentMonth(cell)"
+          type="button"
+          @click="selectDay(cell)"
+          :disabled="isDisabledCell(cell)"
+          :class="[
+            'aspect-square rounded-lg text-sm flex items-center justify-center transition-colors',
+            isDisabledCell(cell)
+              ? 'text-gray-300 cursor-not-allowed'
+              : isSameDay(cell, modelValue)
+                ? 'bg-primary text-white font-semibold'
+                : isSameDay(cell, todayMidnight) && !isSameDay(cell, modelValue)
+                  ? 'border border-primary text-primary font-semibold hover:bg-primary hover:text-white cursor-pointer'
+                  : 'text-gray-700 hover:bg-primary hover:text-white cursor-pointer',
+          ]"
+          :aria-label="cell.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })"
+          :aria-pressed="isSameDay(cell, modelValue)"
+        >
+          {{ cell.getDate() }}
+        </button>
+        <div
+          v-else
+          class="aspect-square rounded-lg"
+          aria-hidden="true"
+        ></div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/composables/useDate.ts
+++ b/composables/useDate.ts
@@ -1,0 +1,63 @@
+// composables/useDate.ts
+//
+// Pure date helpers for the booking page. No Vue / Nuxt imports — keeps the
+// helpers trivially testable and reusable from both the page and the
+// CalendarMonthGrid component. Extracted from pages/booking/index.vue as part
+// of dev-v0.1.7 (month-grid calendar view).
+
+/**
+ * Format a Date as `YYYY-MM-DD` using its local time fields. Suitable for the
+ * `date` query param on `/api/booking/availability`.
+ */
+export function toYYYYMMDD(date: Date): string {
+  const year = date.getFullYear()
+  const month = (date.getMonth() + 1).toString().padStart(2, '0')
+  const day = date.getDate().toString().padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * Build the 42-cell (6 rows × 7 cols) month grid for a calendar view, starting
+ * at the Sunday on-or-before the 1st of `displayMonth` and ending at the
+ * Saturday on-or-after the last day. Out-of-month padding days are included so
+ * callers can render them as inert cells.
+ */
+export function buildMonthGrid(displayMonth: Date): Date[] {
+  const firstOfMonth = new Date(displayMonth.getFullYear(), displayMonth.getMonth(), 1)
+  const gridStart = new Date(firstOfMonth)
+  gridStart.setDate(firstOfMonth.getDate() - firstOfMonth.getDay()) // Sunday = 0
+
+  const cells: Date[] = []
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(gridStart)
+    d.setDate(gridStart.getDate() + i)
+    cells.push(d)
+  }
+  return cells
+}
+
+/**
+ * True when `a` and `b` fall on the same calendar day in their local time
+ * zone. Used for selected-day and today highlighting in the calendar grid.
+ */
+export function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+/**
+ * Return `date` clamped to the inclusive range [min, max]. If `date` is before
+ * `min`, returns a copy of `min`; if after `max`, returns a copy of `max`;
+ * otherwise returns a copy of `date` itself. None of the inputs are mutated.
+ */
+export function clampDate(date: Date, min: Date, max: Date): Date {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  const minD = new Date(min.getFullYear(), min.getMonth(), min.getDate())
+  const maxD = new Date(max.getFullYear(), max.getMonth(), max.getDate())
+  if (d.getTime() < minD.getTime()) return minD
+  if (d.getTime() > maxD.getTime()) return maxD
+  return d
+}

--- a/composables/useDate.ts
+++ b/composables/useDate.ts
@@ -17,10 +17,12 @@ export function toYYYYMMDD(date: Date): string {
 }
 
 /**
- * Build the 42-cell (6 rows × 7 cols) month grid for a calendar view, starting
- * at the Sunday on-or-before the 1st of `displayMonth` and ending at the
- * Saturday on-or-after the last day. Out-of-month padding days are included so
- * callers can render them as inert cells.
+ * Build the month grid for a calendar view, starting at the Sunday on-or-
+ * before the 1st of `displayMonth` and ending at the Saturday on-or-after the
+ * last day. The returned array contains 28, 35, or 42 cells (4–6 weeks ×
+ * 7 cols): trailing all-out-of-month weeks are trimmed so single-month views
+ * don't render an empty band beneath the last row. Out-of-month padding days
+ * are included in the first row(s) so callers can render them as inert cells.
  */
 export function buildMonthGrid(displayMonth: Date): Date[] {
   const firstOfMonth = new Date(displayMonth.getFullYear(), displayMonth.getMonth(), 1)
@@ -32,6 +34,14 @@ export function buildMonthGrid(displayMonth: Date): Date[] {
     const d = new Date(gridStart)
     d.setDate(gridStart.getDate() + i)
     cells.push(d)
+  }
+  // Trim trailing all-out-of-month weeks so the grid is 28/35/42 cells,
+  // not always 42. Keeps the calendar tight against the last visible row.
+  while (
+    cells.length > 7
+    && cells.slice(-7).every((d) => d.getMonth() !== displayMonth.getMonth())
+  ) {
+    cells.length -= 7
   }
   return cells
 }

--- a/pages/booking/index.vue
+++ b/pages/booking/index.vue
@@ -20,6 +20,11 @@ const route = useRoute()
 const selectedDate = ref(new Date())
 const bookingWindowDays = 30
 const availableSlots = ref<TimeSlot[]>([])
+// Calendar bounds. `today` is captured at mount so the bounds do not drift
+// while the page is open; matches the prior day-stepper's behaviour where
+// the prev-day button was disabled once the selected day was today.
+const today = new Date()
+const maxBookingDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + bookingWindowDays)
 const selectedSlot = ref<TimeSlot | null>(null)
 const isLoading = ref(false)
 const error = ref<string | null>(null)
@@ -39,22 +44,6 @@ const formattedDate = computed(() => {
     month: 'long',
     day: 'numeric',
   })
-})
-
-const isPreviousDayDisabled = computed(() => {
-  const today = new Date()
-  const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate())
-  const selected = selectedDate.value
-  const startOfSelected = new Date(selected.getFullYear(), selected.getMonth(), selected.getDate())
-  return startOfSelected.getTime() <= startOfToday.getTime()
-})
-
-const isNextDayDisabled = computed(() => {
-  const today = new Date()
-  const limitDate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + bookingWindowDays)
-  const selected = selectedDate.value
-  const startOfSelected = new Date(selected.getFullYear(), selected.getMonth(), selected.getDate())
-  return startOfSelected.getTime() >= limitDate.getTime()
 })
 
 // timezoneIana is the visitor's IANA timezone name (e.g. "Europe/Berlin").
@@ -103,12 +92,6 @@ async function fetchAvailability(date: Date) {
   } finally {
     isLoading.value = false
   }
-}
-
-function changeDay(amount: number) {
-  const currentDate = selectedDate.value
-  const newDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate() + amount)
-  selectedDate.value = newDate
 }
 
 function selectSlot(slot: TimeSlot) {
@@ -174,33 +157,16 @@ onMounted(() => {
     <div v-if="!isBookingConfirmed">
       <h1 class="text-2xl font-bold text-dark-slate mb-6 text-center">Book a Consultation</h1>
 
-      <!-- Date Selector -->
-      <div class="flex items-center justify-between mb-6">
-        <button
-          @click="changeDay(-1)"
-          class="btn-day-nav"
-          :disabled="isPreviousDayDisabled || isLoading"
-          aria-label="Previous day"
-        >
-          <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
-          </svg>
-        </button>
-        <div class="text-center">
-          <h3 class="text-lg font-semibold text-gray-700">{{ formattedDate }}</h3>
-          <p class="text-xs text-gray-500">Timezone: {{ timezone }}</p>
-        </div>
-        <button
-          @click="changeDay(1)"
-          class="btn-day-nav"
-          :disabled="isNextDayDisabled || isLoading"
-          aria-label="Next day"
-        >
-          <svg class="w-6 h-6 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
-          </svg>
-        </button>
+      <!-- Date Selector — month-grid calendar view -->
+      <div class="mb-2">
+        <BookingCalendarMonthGrid
+          v-model="selectedDate"
+          :min-date="today"
+          :max-date="maxBookingDate"
+          :disabled="isLoading"
+        />
       </div>
+      <p class="text-xs text-gray-500 text-center mb-6">Timezone: {{ timezone }}</p>
 
       <!-- Error Message -->
       <div v-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
@@ -214,6 +180,9 @@ onMounted(() => {
 
       <!-- Time Slots -->
       <div v-else-if="!selectedSlot" class="min-h-[100px]">
+        <h4 class="text-sm font-medium text-gray-600 mb-3 text-center">
+          Available slots for {{ formattedDate }}
+        </h4>
         <div v-if="availableSlots.length > 0" class="grid grid-cols-2 sm:grid-cols-3 gap-4">
           <button
             v-for="slot in availableSlots"

--- a/pages/booking/index.vue
+++ b/pages/booking/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { getGaSessionInfo } from '~/services/analytics'
+import { toYYYYMMDD } from '~/composables/useDate'
 
 useSeoMeta({
   title: 'Contact us | ivmanto.com',
@@ -71,13 +72,6 @@ const timezone = computed(() => {
   const iana = timezoneIana.value
   return iana ? iana.replace(/_/g, ' ') : 'Unknown'
 })
-
-function toYYYYMMDD(date: Date) {
-  const year = date.getFullYear()
-  const month = (date.getMonth() + 1).toString().padStart(2, '0')
-  const day = date.getDate().toString().padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
 
 async function fetchAvailability(date: Date) {
   isLoading.value = true

--- a/tasks/2026-06-10-booking-month-grid-calendar.md
+++ b/tasks/2026-06-10-booking-month-grid-calendar.md
@@ -1,0 +1,72 @@
+# Task: replace day-stepper with month-grid calendar view (`/booking`)
+
+- **Status:** in progress
+- **Branch:** `dev-v0.1.7` (sequential +1 from merged `dev-v0.1.6`, PR #93)
+- **Owner:** Nick (approved via Clauco's task on redma thread `calendar-view-booking-v0.1.7`, 2026-06-09T20:27:39Z)
+- **Reviewer:** Clauco (contract: `.agents/pr-review-contract.md`)
+
+## Goal
+
+Replace the prev/next-day arrow stepper on `pages/booking/index.vue:184-209` with a month-grid date picker. Visitors see the full 30-day booking window at a glance instead of clicking through one day at a time.
+
+## Locked design decisions (from Clauco's task brief — do not re-ask)
+
+1. **Replace the day-stepper entirely.** No "calendar + stepper" hybrid.
+2. **No availability dots on calendar cells in this pass.** Slots fetched only on day-click.
+
+## Files
+
+**New:**
+- `composables/useDate.ts` — pure helpers (`toYYYYMMDD`, `buildMonthGrid`, `isSameDay`, `clampDate`).
+- `components/booking/CalendarMonthGrid.vue` — month-grid picker, v-model on `selectedDate`.
+
+**Modified:**
+- `pages/booking/index.vue` — drop `changeDay`, `isPreviousDayDisabled`, `isNextDayDisabled`; replace date-selector block (lines 184-209) with `<CalendarMonthGrid>`. Drop inline `toYYYYMMDD` in favour of the composable import.
+
+## Invariants from PR #93 (must survive)
+
+- `timezoneIana` computed for POST body (raw IANA name).
+- `timezone` computed for visible "Timezone: ..." label (underscores → spaces, "Unknown" fallback).
+- `?topic=&summary=` deep-link prefill on `onMounted`.
+- GA4 `getGaSessionInfo` clientId/sessionId on POST body.
+- Real-time availability fetched client-side from `/api/booking/availability` (STRICT rule #4).
+- No touches to `cloudbuild.yaml`, `backend/internal/gcal/`, `cmd/server/main.go`, Secret Manager refs, or `plugins/analytics.client.ts` cookie-consent gating.
+
+## Pre-PR gate strategy
+
+- **Toolchain state on workstation:** `gh` ✓ (dasiyes, repo scope); `node`/`npm` ✓; `go` ✗; `node_modules` ✗.
+- **Frontend gates (`npm run lint`, `npm run generate`):** deferred to CI / owner — see "Notes / risks" in the PR body. `npm run lint` was already broken on `main` for a pre-existing eslint-config reason (Clauco flagged on PR #93 review). `node_modules` would require either `npm install` (network + a one-time setup) or owner running locally.
+- **Manual interaction verification:** deferred to Clauco per task brief ("I'll capture a desktop + mobile screenshot during review... You don't need to provide screenshots yourself — verifying interaction is enough."). I'll run a self-verification pass against the source for the listed interaction points.
+- **Backend:** untouched, no `go build` / `go test` needed.
+
+## Implementation steps
+
+1. Cut branch `dev-v0.1.7` from main.
+2. **Commit 1:** `feat(booking): extract date helpers into composables/useDate.ts` — new `composables/useDate.ts` with the four pure helpers. `pages/booking/index.vue` swaps the inline `toYYYYMMDD` for the import. No behaviour change visible.
+3. **Commit 2:** `feat(booking): add month-grid calendar view component` — new `components/booking/CalendarMonthGrid.vue` per spec. Not yet wired into the page.
+4. **Commit 3:** `feat(booking): replace day-stepper with month-grid calendar view` — drop the prev/next-day block, mount `<CalendarMonthGrid>`, keep `formattedDate` as the "Available slots for ..." header.
+5. Self-verify against the six interaction points from Clauco's brief.
+6. Push, `gh pr create --body-file`, ping Clauco on the thread with the PR URL.
+
+## Self-verification checklist (run against source before PR)
+
+- [ ] Calendar renders current month, today highlighted as selected.
+- [ ] Future-and-in-window days are clickable; past days and days beyond `maxDate` render as disabled.
+- [ ] Day click emits `update:modelValue` → parent's `watch(selectedDate, fetchAvailability)` fires.
+- [ ] Prev/next month nav does NOT change `selectedDate`; only `displayMonth` shifts.
+- [ ] "Available slots for {{ formattedDate }}" header sits between calendar and slot grid.
+- [ ] Visible "Timezone: ..." label still reads `America/New York` (or `Unknown` if Intl absent); POST body still sends raw IANA.
+- [ ] `?topic=&summary=` deep-link still prefills `bookingDetails.notes` on mount.
+
+## Out of scope (do not touch)
+
+- Backend changes (booking availability, book, cancel, email, gcal package).
+- Per-cell availability dots (needs backend batch endpoint first).
+- Persisting selected date across refreshes.
+- i18n of day/month names (keep `en-US`).
+- Keyboard accessibility for cell navigation.
+- `pages/booking-demo.vue` (leave as-is).
+
+## Review section (to fill in after Clauco reviews)
+
+<!-- Clauco's findings go here. -->


### PR DESCRIPTION
## Summary

Replaces the prev/next-day arrow stepper on `/booking` with a month-grid date picker. Visitors see the full 30-day booking window at a glance instead of clicking through one day at a time. UI-only change — no backend, no API changes.

## Type & scope

- Type: `feat`
- Scope: `booking`

## Linked task

- `tasks/2026-06-10-booking-month-grid-calendar.md` (this branch)
- Clauco's task brief on redma thread `calendar-view-booking-v0.1.7` (2026-06-09T20:27:39Z)
- Plan source: see "Bigger story" in the brief — Google Workspace "Booking Pages" was evaluated as a replacement and ruled out; this is the chosen UI-enhancement path.

## Pre-PR checklist

**Frontend changes:**

- [x] `npm run lint` — **DEFERRED.** `npm run lint` was already broken on `main` for a pre-existing eslint-config reason (flat `eslint.config.ts` with eslint 8.57 in legacy mode). Clauco flagged this in the PR #93 review. Not introduced by this PR. A separate ticket is the right place to fix it.
- [x] `npm run generate` — **DEFERRED.** `node_modules/` is not present on this workstation and the local toolchain has not been bootstrapped. Per the brief, the reviewer is happy to run `npm run generate` on their side. I did not silently `npm install` because of the project's "no side-effect installs without explicit owner consent" rule.
- [x] Verified affected page in source — see "Self-verification" below.

**Backend changes:** N/A — UI-only.

**Always:**

- [x] No secrets in the diff. The new files contain only a new Vue component, a small TS composable with pure date helpers, and a tasks/ plan doc. No env-var names, no `*_PASS` / `*_SECRET` / `*_KEY` / `*_TOKEN`, no OAuth or JWT material.
- [x] No unintended changes to `cloudbuild.yaml`, `backend/internal/gcal/`, `backend/cmd/server/main.go` startup, Secret Manager refs, or `plugins/analytics.client.ts` cookie-consent gating. (`git diff main..HEAD --name-only` is exactly the four expected paths plus the plan doc.)
- [x] Commit messages follow conventional-commits style (`type(scope): summary`). The three code commits are:
  - `feat(booking): extract date helpers into composables/useDate.ts`
  - `feat(booking): add month-grid calendar view component`
  - `feat(booking): replace day-stepper with month-grid calendar view`
- [x] Branch is `dev-v0.1.7` (sequential +1 from merged `dev-v0.1.6` / PR #93).

## New env vars / secrets

None.

## Notes / risks for the reviewer

### Scope-adjacent: scope-addition call

The brief said to follow the existing component directory convention (`components/about/`, `components/services-content/`, etc.), and Nuxt 3's default recursive auto-import resolves `components/booking/CalendarMonthGrid.vue` to `<BookingCalendarMonthGrid>`. I used the prefixed name in `pages/booking/index.vue`. No additional scope was added — this is just the correct way to use the convention the brief required.

### Scope-adjacent: minor UX additions (not blocking — flagging)

Two small visible additions, both called out in the brief's "Interaction model" / "Interaction model" sections but I want to surface them explicitly:

1. **"Timezone: …" label** moved out of the (now-deleted) day-stepper centre column and rendered as a centred `<p>` directly below the calendar. Same text, same `timezone` computed (underscores → spaces, "Unknown" fallback). No content regression.
2. **"Available slots for {{ formattedDate }}"** header added above the slot grid, per the brief's interaction model #4. Uses the existing `formattedDate` computed.

Neither touches invariants from PR #93.

### Local toolchain gaps (already pre-existing, calling out for the record)

- `node_modules/` not present. Did **not** run `npm install` per the "no side-effect installs without explicit consent" rule.
- `go` not on PATH. Not needed for this UI-only PR, but worth noting in case the next agent wonders.

If you want the workstation bootstrapped for future PRs (so `npm run lint` / `npm run generate` can run locally), happy to do that as a separate small task with explicit owner sign-off.

### Verification deferred to reviewer (per brief)

Clauco's brief said: *"The owner explicitly asked to see the UI before merging. I'll capture a desktop + mobile screenshot during review via the preview tools and attach to the review thread. You don't need to provide screenshots yourself — verifying interaction is enough."*

I did the interaction-level verification against the source (see next section). Visual review falls to you, as agreed.

## Self-verification (interaction points from the brief)

I traced through the source for each interaction point the brief listed; here's what should hold when the reviewer runs the page:

1. **Calendar renders for the current month, today highlighted as selected.** `displayMonth` in the component is initialised from `modelValue`, which the page sets to `new Date()` at mount. `isSameDay(cell, modelValue)` paints the today cell `bg-primary text-white font-semibold`. Verified by reading `components/booking/CalendarMonthGrid.vue` lines 24-58 (init) and 153-174 (cell class binding).
2. **Future-and-in-window days are clickable.** `isDisabledCell` (lines 95-98) returns false for any cell within `[minDate, maxDate]`. Click handler `selectDay` (lines 100-106) re-checks before emitting.
3. **Day click → slot grid updates.** The page's `watch(selectedDate, fetchAvailability)` (line 142) fires on any v-model update, including the calendar's `update:modelValue` emission.
4. **Prev/next month nav works; `selectedDate` unchanged on month nav.** `shiftMonth` (lines 108-113) only mutates `displayMonth`. Verified by reading.
5. **Disabled cells are visibly disabled and don't accept clicks.** Both the `:disabled` attribute and the in-handler re-check guard against the click reaching the emit. Disabled class is `text-gray-300 cursor-not-allowed` with no hover.
6. **Mobile viewport (375px) — 7-column grid stays legible.** `grid-cols-7 gap-1` on all breakpoints; `aspect-square` keeps cells square; `text-sm` on the cells. No breakpoint-specific overrides were added in this PR.
7. **PR #93 invariants intact.** `timezoneIana` (raw IANA) is still what the POST body sends (page line 115). `timezone` (display) still feeds the visible label. `?topic=&summary=` deep-link prefill is still in `onMounted` (page lines 144-151). `getGaSessionInfo` still on the POST body (page lines 106-107). `fetchAvailability` still client-side at runtime.
8. **No availability dots in this pass.** Brief explicitly deferred this. The cell does not show availability; slots still fetch on day-click only.

## Out of scope (re-stated, not touched)

- Backend (availability, book, cancel, email, gcal package).
- Per-cell availability dots (needs backend batch endpoint first).
- Persisting selected date across refreshes.
- i18n of day/month names (`en-US` kept).
- Keyboard accessibility for cell navigation.
- `pages/booking-demo.vue` (left as-is).
- The pre-existing `npm run lint` failure on `main` (separate ticket).

## Commit map

```
e7cd071 docs(tasks): add v0.1.7 plan for month-grid calendar view
80b7184 feat(booking): replace day-stepper with month-grid calendar view
4d1017c feat(booking): add month-grid calendar view component
470d493 feat(booking): extract date helpers into composables/useDate.ts
```
