### PR TITLE
feat(booking): extend booking window from 30 to 90 days

### DIFF
--- a/pages/booking/index.vue
+++ b/pages/booking/index.vue
@@ -18,7 +18,11 @@ type TimeSlot = {
 const route = useRoute()
 
 const selectedDate = ref(new Date())
-const bookingWindowDays = 30
+// Visitors can book up to ~3 months ahead. The AfB scheduler (see
+// ~/.hermes/profiles/ivmo/scripts/afb_scheduler.py) populates events with
+// WEEKS_AHEAD=12 starting 4 weeks out, so the 90-day window always has
+// bookable slots once the Monday cron has run for the week.
+const bookingWindowDays = 90
 const availableSlots = ref<TimeSlot[]>([])
 // Calendar bounds. `today` is captured at mount so the bounds do not drift
 // while the page is open; matches the prior day-stepper's behaviour where

--- a/tasks/2026-06-13-booking-3-month-window.md
+++ b/tasks/2026-06-13-booking-3-month-window.md
@@ -1,0 +1,125 @@
+# Task: extend booking window to 3 months on `/booking`
+
+- **Status:** in progress
+- **Branch:** `dev-v0.1.8` (sequential +1 from merged `dev-v0.1.7`, PR #94)
+- **Owner:** Nick (kickoff in chat, 2026-06-13 ~02:00; not yet Clauco-approved — night-shift work)
+- **Reviewer:** Clauco (contract: `.agents/pr-review-contract.md`)
+
+## Goal
+
+The booking page (`/booking`) currently caps the navigable date range at
+`today + 30 days` via `const bookingWindowDays = 30` in
+`pages/booking/index.vue`. The AfB Consultancy Google Calendar has AfB events
+populated through end of July but no further; the website's month-grid
+calendar (introduced in PR #94) allows navigation up to today+30d and then
+the next-month button is disabled. Result: visitors can see at most the
+first ~3 weeks of July and the page then appears "empty" — the slots are
+real, but the UI can't reach them.
+
+Fix: bump `bookingWindowDays` to 90 (≈3 months) and align the AfB scheduler
+to populate events that cover a 90-day rolling window.
+
+## Locked design decisions (do not re-ask)
+
+1. **90 days, not 120.** "3 months" interpreted as ~13 weeks, not a full
+   quarter. 90 days fits `today → today + 90d` cleanly.
+2. **Use the existing `bookingWindowDays` constant, not a config flag.** The
+   page already uses it for `maxBookingDate`. No new prop, no new env var.
+3. **Bump scheduler `WEEKS_AHEAD` to 12, not introduce a calendar-length
+   constant.** The scheduler's create window stays anchored at
+   `now + 4 weeks` (matches existing semantics — slots visible ≥ 4 weeks
+   out) and just extends 4 → 12 weeks.
+4. **Add identity-based dedup to the scheduler** while we're in there.
+   Without it, the next Monday cron run would see "the day has 2 AfB
+   events at e.g. 09:30 and 14:00", pick a non-overlapping slot at 11:00,
+   and create a third. With the new per-day count guard (`already >= 2 →
+   skip`), the scheduler is idempotent across runs and won't double-fill
+   days that are already at capacity.
+5. **Backfill now, don't wait for next Monday.** Run the scheduler
+   manually after the source change so the calendar is full when the
+   morning comes.
+6. **No backend changes.** The availability handler
+   (`backend/internal/booking/handler.go:handleGetAvailability`) just
+   queries the calendar for the requested date; no implicit date cap.
+
+## Files
+
+**Modified:**
+- `pages/booking/index.vue` — `bookingWindowDays` 30 → 90, plus a 4-line
+  comment cross-referencing the scheduler.
+- `~/.hermes/profiles/ivmo/scripts/afb_scheduler.py` — `WEEKS_AHEAD` 4 →
+  12, identity-based dedup (per-day AfB count guard) in the main loop.
+- `~/.hermes/profiles/ivmo/skills/ivmo/calendar-scheduler-automation/SKILL.md`
+  — update the AfB-hardcoded-constants table (WEEKS_AHEAD 4 → 12) and
+  note the new identity-based dedup behaviour.
+
+**Not touched:**
+- `components/booking/CalendarMonthGrid.vue` — the month-grid component
+  already respects the parent's `:max-date` prop, so it scales for free
+  to 90 days. Verified by reading lines 21-49 and 82-87.
+- `backend/internal/booking/handler.go` — N/A.
+- `composables/useDate.ts` — N/A.
+- `cloudbuild.yaml`, `backend/internal/gcal/`, `cmd/server/main.go`
+  startup, Secret Manager refs, `plugins/analytics.client.ts` consent
+  gating — not in scope.
+
+## Pre-PR gate strategy
+
+- **`npm run generate`** — ran locally, **PASS**. 122 routes prerendered,
+  exit 0, no errors. (Deferred tooling-gap from PR #94 no longer applies
+  here — `node_modules/` is present on this workstation as of the
+  night-shift.)
+- **`npm run lint`** — DEFERRED. Still broken on `main` for the
+  pre-existing eslint-config reason (flat `eslint.config.ts` vs pinned
+  ESLint 8.57) flagged in PR #93 review. Not introduced by this PR.
+  Tracked separately.
+- **Manual page verification** — deferred to Clauco per the pattern from
+  PR #94. The diff is one constant + 4 lines of comment; interaction
+  surface is unchanged.
+- **Backend** — untouched, no `go build` / `go test` needed.
+
+## Backfill run
+
+After the source change, ran:
+
+```
+python3 ~/.hermes/profiles/ivmo/scripts/afb_scheduler.py --weeks-ahead 12
+```
+
+Result: **Created 90 AfB events, 0 errors, 15 days skipped** (the 15
+working days July 11 → July 31 that already had 2 AfB events each from
+the previous run).
+
+Post-run inspection (`afb_inspect.py --from 2026-06-13 --to 2026-10-15`):
+**70 working days, June 15 → October 2, every one with exactly 2 AfB
+events, 0 duplicates, 0 overlaps, 0 non-AfB conflicts.** The 90-day
+window (today + 90 = Sept 11) is fully populated; the scheduler leaves
+~3 weeks of headroom (→ Oct 2) for the next Monday cron to refill from.
+
+## Self-verification checklist (run against source)
+
+- [ ] `bookingWindowDays = 90` in `pages/booking/index.vue` (line 21 area).
+- [ ] `WEEKS_AHEAD = 12` in `~/.hermes/profiles/ivmo/scripts/afb_scheduler.py`
+      (line 45).
+- [ ] Identity-based dedup: `existing_afb_per_day` precomputed and
+      consulted before slot generation in the scheduler main loop.
+- [ ] `today + 90` actually allows navigating to Sept 11. Verified by
+      reading the `maxBookingDate` line in the page and the
+      `isNextMonthDisabled` gate in the month-grid component
+      (`CalendarMonthGrid.vue:82-87`).
+- [ ] Weekend cells in the month-grid still render as clickable (existing
+      behaviour). Days with no AfB events will show "There are no
+      available slots for this day" (existing copy, unchanged). Out of
+      scope to grey out weekends — would be a small follow-up if the
+      owner wants it.
+- [ ] `pages/booking-demo.vue` (the iframe-embed variant) is left
+      untouched. It has its own data path and is not part of this fix.
+
+## Out of scope (re-stated, not touched)
+
+- Per-cell availability dots on the month grid (still deferred per the
+  PR #94 brief).
+- Persisting the selected date across refreshes.
+- i18n of day/month names.
+- `npm run lint` eslint-config fix (separate ticket).
+- Weekend-cell grey-out.


### PR DESCRIPTION
## Summary

The `/booking` page capped the navigable date range at `today + 30 days` via `const bookingWindowDays = 30` in `pages/booking/index.vue`. After PR #94 replaced the day-stepper with a month-grid calendar, the visible grid was bounded to today+30d, so the next-month button was disabled as soon as the visitor reached the first week of the second month. The AfB Consultancy Google Calendar was populated beyond that point (cleaned up to 2-per-day on the night of 2026-06-13) but the website couldn't navigate to those slots.

Bump the constant to **90 days** so the booking UI exposes the same 3-month horizon the AfB scheduler (now with `WEEKS_AHEAD=12`, also adjusted out-of-repo) keeps populated. The month-grid component (`components/booking/CalendarMonthGrid.vue`) already respects the parent's `:max-date` prop, so no UI change is needed beyond the constant — verified by reading lines 21-49 and 82-87.

The backend (`backend/internal/booking/handler.go:handleGetAvailability`) just queries the calendar for the requested date with no implicit cap, so no backend change is required.

## Type & scope

- Type: `feat`
- Scope: `booking`

## Linked task

- `tasks/2026-06-13-booking-3-month-window.md`
- Kickoff: in chat 2026-06-13 ~02:00 (night-shift)
- Out-of-repo companion change: `~/.hermes/profiles/ivmo/scripts/afb_scheduler.py` `WEEKS_AHEAD` 4 → 12 + identity-based dedup (per-day AfB-count guard). Not in this PR's diff because that script lives in the Hermes profile tree, not the ivmanto.com repo. Backfill run (90 events created, 0 errors) and post-run inspection (70 working days Jun 15 → Oct 2, every one with exactly 2 AfB events) are recorded in the linked task doc.

## Pre-PR checklist

**Frontend changes:**

- [x] `npm run lint` — **DEFERRED.** Still broken on `main` for the pre-existing eslint-config reason (flat `eslint.config.ts` with ESLint 8.57 in legacy mode) flagged in PR #93 review. Not introduced by this PR.
- [x] `npm run generate` — **PASSED locally.** Last 5 lines:
  ```
  [nitro] ℹ Prerendered 122 routes in 2.666 seconds
  [nitro] ✔ Generated public .output/public
  [nitro] ✔ You can preview this build using npx serve .output/public
  │
  └  ✨ You can now deploy .output/public to any static hosting!
  ```
  Full output confirms exit 0, no errors. `node_modules/` is present on this workstation, so the deferred-toolchain gap from PR #94 does not apply here.
- [x] Verified affected page in source — see "Self-verification" below.

**Backend changes:** N/A — UI-only.

**Always:**

- [x] No secrets in the diff. Only `pages/booking/index.vue` (1 line changed, 4 lines of comment) and `tasks/2026-06-13-booking-3-month-window.md` (new plan doc).
- [x] No unintended changes to `cloudbuild.yaml`, `backend/internal/gcal/`, `backend/cmd/server/main.go` startup, Secret Manager refs, or `plugins/analytics.client.ts` cookie-consent gating. (`git diff main..HEAD --name-only` is exactly the two expected paths.)
- [x] Commit message follows conventional-commits style (`feat(booking): extend booking window from 30 to 90 days`).
- [x] Branch is `dev-v0.1.8` (sequential +1 from merged `dev-v0.1.7` / PR #94).

## New env vars / secrets

None.

## Notes / risks for the reviewer

### Minimal surface

The production change is exactly:

```diff
-const bookingWindowDays = 30
+// Visitors can book up to ~3 months ahead. The AfB scheduler (see
+// ~/.hermes/profiles/ivmo/scripts/afb_scheduler.py) populates events with
+// WEEKS_AHEAD=12 starting 4 weeks out, so the 90-day window always has
+// bookable slots once the Monday cron has run for the week.
+const bookingWindowDays = 90
```

That's the entire UI diff. The rest of the file (the `<CalendarMonthGrid>` mount, the `watch(selectedDate, fetchAvailability)` reactivity, the POST body, the GA4 session info, the `?topic=&summary=` deep-link prefill, the `formattedDate` "Available slots for …" header) is untouched and all PR #93 / #94 invariants survive.

### Out-of-repo scheduler change

The `WEEKS_AHEAD` bump and the identity-based dedup live in `~/.hermes/profiles/ivmo/scripts/afb_scheduler.py`, not in this repo. That script runs as a Monday cron (`hermes cronjob id=68ddbbbaaf4a`) and populates the AfB calendar. The change is mentioned here so the reviewer can see the full picture, but the script diff itself is intentionally not part of this PR (it would belong in a separate Hermes profile change).

### Why identity-based dedup matters here

Before this change, the scheduler's dedup was *overlap-based*: a proposed slot was rejected only if it overlapped an existing event on the same day. A day with 2 AfB events at 09:30 and 14:00 had no slots at those exact times free, but the scheduler would happily create events at 11:00 and 16:00, silently doubling the daily count on every Monday run. The new guard — "if the day already has `>= EVENTS_PER_DAY` AfB events, skip the day entirely" — makes the scheduler idempotent across runs. This is Rule 3 of the `calendar-scheduler-automation` skill, which the existing script had not implemented yet.

### Self-verification (interaction points)

Traced through the source:

1. **Today+90 is the new `maxBookingDate`.** `maxBookingDate` is `today + bookingWindowDays` = `today + 90d`. The `isNextMonthDisabled` gate in `CalendarMonthGrid.vue:82-87` compares the displayed month against `maxDate` — so the next-month button now stays enabled through the month containing `today + 90d`.
2. **The grid renders 6×7 cells per month, out-of-month cells are inert.** Unchanged from PR #94.
3. **Day click → slot fetch.** The page's `watch(selectedDate, fetchAvailability)` (line 142 area, post-PR #94) still fires; the calendar's `update:modelValue` emission triggers it. The backend handler queries the calendar for that date, which is now populated through October 2.
4. **Past days still disabled.** `isDisabledCell` (`CalendarMonthGrid.vue:95-98`) still rejects cells before `minDate`. No regression.
5. **PR #93 / #94 invariants intact.** `timezoneIana` (raw IANA, POST body) and `timezone` (display, "Unknown" fallback) unchanged. `?topic=&summary=` deep-link prefill unchanged. `getGaSessionInfo` still on the POST body. Client-side availability fetch unchanged.

### Out of scope (re-stated, not touched)

- Per-cell availability dots on the month grid (still deferred per the PR #94 brief).
- Persisting selected date across refreshes.
- i18n of day/month names.
- `npm run lint` eslint-config fix (separate ticket).
- Weekend-cell grey-out (would be a small follow-up if the owner wants it).
- The AfB scheduler's `WEEKS_AHEAD` bump and the identity-based dedup (separate Hermes profile change; not in this PR's diff).
- The backfill run that already populated Aug + early Oct on the AfB calendar (operational, recorded in the linked task doc).
