### PR TITLE
fix(seo): 301-redirect legacy blog slugs, remove broken SearchAction schema

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -40,14 +40,6 @@ useHead({
         publisher: {
           '@id': 'https://ivmanto.com/#organization',
         },
-        potentialAction: {
-          '@type': 'SearchAction',
-          target: {
-            '@type': 'EntryPoint',
-            urlTemplate: 'https://ivmanto.com/blog?q={search_term_string}',
-          },
-          'query-input': 'required name=search_term_string',
-        },
       }),
     },
   ],

--- a/public/serve.json
+++ b/public/serve.json
@@ -1,0 +1,46 @@
+{
+  "redirects": [
+    { "source": "/search", "destination": "/blog", "type": 301 },
+    {
+      "source": "/blog/2026-04-20-common-architectural-patterns",
+      "destination": "/blog/common-architectural-patterns",
+      "type": 301
+    },
+    {
+      "source": "/blog/2026-05-11-ai-agents-always-on-workflows",
+      "destination": "/blog/ai-agents-always-on-workflows",
+      "type": 301
+    },
+    {
+      "source": "/blog/2026-05-18-the-pivot-to-agentic-ai-usage-based-pricing",
+      "destination": "/blog/the-pivot-to-agentic-ai-usage-based-pricing",
+      "type": 301
+    },
+    {
+      "source": "/blog/CommonArchitecturalPatterns",
+      "destination": "/blog/common-architectural-patterns",
+      "type": 301
+    },
+    {
+      "source": "/blog/VertexAiProduction",
+      "destination": "/blog/vertex-ai-production-gotchas",
+      "type": 301
+    },
+    {
+      "source": "/blog/DamaPrinciples",
+      "destination": "/blog/dama-ai-governance",
+      "type": 301
+    },
+    {
+      "source": "/blog/_FromBigDataTo",
+      "destination": "/blog/FromBigDataTo",
+      "type": 301
+    }
+  ],
+  "headers": [
+    {
+      "source": "_nuxt/**",
+      "headers": [{ "key": "X-Robots-Tag", "value": "noindex" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Google Search Console reports **39 not-indexed pages** for ivmanto.com. Investigation showed most trace back to two blog slug-scheme migrations (CamelCase → dated → kebab-case) that left the old URLs 404ing with no redirects, plus a `SearchAction` schema in the global `WebSite` JSON-LD advertising a `/search` endpoint that doesn't exist — Google crawls the literal `{search_term_string}` template as a URL.

## What

- **`public/serve.json`** (new) — picked up automatically by `serve` in the frontend container, copied into `.output/public` by `nuxi generate`:
  - 301 redirects for legacy slugs that have a living successor:
    | old | new |
    |---|---|
    | `/blog/2026-04-20-common-architectural-patterns` | `/blog/common-architectural-patterns` |
    | `/blog/2026-05-11-ai-agents-always-on-workflows` | `/blog/ai-agents-always-on-workflows` |
    | `/blog/2026-05-18-the-pivot-to-agentic-ai-usage-based-pricing` | `/blog/the-pivot-to-agentic-ai-usage-based-pricing` |
    | `/blog/CommonArchitecturalPatterns` | `/blog/common-architectural-patterns` |
    | `/blog/VertexAiProduction` | `/blog/vertex-ai-production-gotchas` |
    | `/blog/DamaPrinciples` | `/blog/dama-ai-governance` |
    | `/blog/_FromBigDataTo` | `/blog/FromBigDataTo` |
    | `/search` | `/blog` |
  - `X-Robots-Tag: noindex` on `/_nuxt/**` so self-hosted fonts and build artifacts stop showing up in the GSC report.
- **`layouts/default.vue`** — removed the `potentialAction`/`SearchAction` block (`/blog` has no `?q=` handling).

Deliberately **not** redirected: deleted articles with no successor (`TheRiseOfSlm`, `GuideToTailwind`, `FutureOfWeb`, `MasteringVue3`) keep 404ing — correct signal for removed content.

## Verification

- Tested `serve.json` against the real `serve` package locally: 301s resolve to the right targets, `_nuxt` assets return `X-Robots-Tag: noindex`, clean URLs still work.
- `npm run generate` passes (132 routes prerendered); `serve.json` present in `.output/public`; `SearchAction`/`search_term_string` gone from generated HTML.

## After merge/deploy (manual GSC steps)

1. Validate Fix on "Not found (404)" and "Redirect error" in Search Console.
2. Request indexing for the redirect targets via URL Inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)